### PR TITLE
Fixing libpng build on OS X

### DIFF
--- a/lib/ccv_io.c
+++ b/lib/ccv_io.c
@@ -3,9 +3,25 @@
 #ifdef HAVE_LIBJPEG
 #include <jpeglib.h>
 #endif
+
 #ifdef HAVE_LIBPNG
-#include <libpng/png.h>
+  #ifdef __APPLE__
+    #include "TargetConditionals.h"
+    #if TARGET_OS_IPHONE
+         // iOS
+    #elif TARGET_IPHONE_SIMULATOR
+        // iOS Simulator
+    #elif TARGET_OS_MAC
+      #include <zlib.h>
+      #include <png.h>
+    #else
+        // Unsupported platform
+    #endif
+  #else
+    #include <libpng/png.h>
+  #endif
 #endif
+
 #ifdef HAVE_LIBJPEG
 #include "io/_ccv_io_libjpeg.c"
 #endif

--- a/lib/configure
+++ b/lib/configure
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ `uname` == "Darwin" ] ; then
+  IS_OSX=true
+fi
+
 if [ "$1" = "force" ] ; then
 	rm -f .CC .DEF .LN
 fi
@@ -49,6 +53,10 @@ else
 	[nN]* ) ;;
 	*	  ) CFLAGS="$CFLAGS-D HAVE_LIBPNG "
 			LDFLAGS="$LDFLAGS-lpng -lz "
+      if [[ $IS_OSX ]] ; then
+        CFLAGS="$CFLAGS-I/usr/X11/include "
+        LDFLAGS="$LDFLAGS-L/usr/X11/lib "
+      fi
 			;;
 	esac
 	echo -ne "  With \033[4mgsl\033[m [Y/n] ? "


### PR DESCRIPTION
Building ccv under OSX with libpng with a non-xcode build was broken.

OS X comes with libpng built-in at /usr/X11/{include,lib}. I've updated the configure script to include those locations via -I and -L, respectively, and added a conditional to include the header file under the name "png.h". It looks like you're using a #define from zlib, so I've included that too.
