### PR TITLE
Change build system to CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bin/*.diff
 bin/data/*
 data/*
 tool/*
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(ccv C)
+cmake_minimum_required(VERSION 2.8)
+enable_testing()
+
+# Add any custom CMake modules we include to the module path.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
+# Unless specified explicitly, use the RelWithDebInfo build type which enables optimisations and
+# debug information.
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Compiler specific flags
+if(NOT WIN32)
+	set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS} -std=c99")
+endif(NOT WIN32)
+
+# The CCV library itself
+add_subdirectory(lib)
+
+# Add the CCV library directory to the include path for subsequent steps
+include_directories("${CMAKE_SOURCE_DIR}/lib")
+
+# Tools provided by the library
+add_subdirectory(bin)
+
+# Testing
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ implementation is what it lacks of. After years, we stuck in between either the
 high-performance, battle-tested but old algorithm implementations, or the new,
 shining but Matlab algorithms. ccv is my take on this problem, hope you enjoy
 it.
+
+Building
+--------
+
+The CMake build system is used to configure and build ccv. It is recommended
+that you build out of the source tree in a dedicated 'build' directory:
+
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ make all && make test
+

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -1,0 +1,40 @@
+# - Find CBLAS
+# Find the native CBLAS headers and libraries.
+#
+#  CBLAS_LIBRARIES    - List of libraries when using cblas.
+#  CBLAS_FOUND        - True if cblas found.
+#
+# Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+find_library(CBLAS_LIBRARY NAMES cblas gslcblas HINTS $ENV{CBLASDIR}/lib $ENV{CBLASDIR}/lib64 )
+
+set(CBLAS_LIBRARIES ${CBLAS_LIBRARY} )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set FFTW3_FOUND to TRUE
+# if all listed variables are TRUE
+
+find_package_handle_standard_args(CBLAS DEFAULT_MSG CBLAS_LIBRARY )
+
+if (CBLAS_FOUND)
+  include(CheckLibraryExists)
+  check_library_exists("${CBLAS_LIBRARY}" cblas_dsyrk "" FOUND_DSYRK)
+  if(NOT FOUND_DSYRK)
+    message(FATAL_ERROR "Could not find cblas_dsyrk in ${CBLAS_LIBRARY}, take a look at the error message in ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log to find out what was going wrong. If you don't have pkg-config installed you will most likely have to set CBLAS_LIBRARY by hand (i.e. -DCBLAS_LIBRARY='/path/to/libcblas.so') !")
+  endif(NOT FOUND_DSYRK)
+endif (CBLAS_FOUND)
+
+mark_as_advanced( CBLAS_LIBRARY )

--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -1,0 +1,23 @@
+if (FFTW_INCLUDES AND FFTW_LIBRARIES)
+  set(FFTW_FIND_QUIETLY TRUE)
+endif (FFTW_INCLUDES AND FFTW_LIBRARIES)
+
+find_path(FFTW_INCLUDES
+  NAMES
+  fftw3.h
+  PATHS
+  $ENV{FFTWDIR}
+  ${INCLUDE_INSTALL_DIR}
+)
+
+find_library(FFTWF_LIB NAMES fftw3f PATHS $ENV{FFTWDIR} ${LIB_INSTALL_DIR})
+find_library(FFTW_LIB NAMES fftw3 PATHS $ENV{FFTWDIR} ${LIB_INSTALL_DIR})
+find_library(FFTWL_LIB NAMES fftw3l  PATHS $ENV{FFTWDIR} ${LIB_INSTALL_DIR})
+set(FFTW_LIBRARIES "${FFTWF_LIB} ${FFTW_LIB} ${FFTWL_LIB}" )
+message(STATUS "FFTW ${FFTW_LIBRARIES}" )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFTW DEFAULT_MSG
+                                  FFTW_INCLUDES FFTW_LIBRARIES)
+
+mark_as_advanced(FFTW_INCLUDES FFTW_LIBRARIES)

--- a/cmake/Modules/FindGSL.cmake
+++ b/cmake/Modules/FindGSL.cmake
@@ -1,0 +1,135 @@
+# Try to find gnu scientific library GSL
+# See 
+# http://www.gnu.org/software/gsl/  and 
+# http://gnuwin32.sourceforge.net/packages/gsl.htm
+#
+# Based on a script of Felix Woelk and Jan Woetzel
+# (www.mip.informatik.uni-kiel.de)
+# 
+# It defines the following variables:
+#  GSL_FOUND - system has GSL lib
+#  GSL_INCLUDE_DIRS - where to find headers 
+#  GSL_LIBRARIES - full path to the libraries
+#  GSL_LIBRARY_DIRS, the directory where the PLplot library is found.
+ 
+#  CMAKE_GSL_CXX_FLAGS  = Unix compiler flags for GSL, essentially "`gsl-config --cxxflags`"
+#  GSL_LINK_DIRECTORIES = link directories, useful for rpath on Unix
+#  GSL_EXE_LINKER_FLAGS = rpath on Unix
+ 
+set( GSL_FOUND OFF )
+set( GSL_CBLAS_FOUND OFF )
+ 
+# Windows, but not for Cygwin and MSys where gsl-config is available
+if( WIN32 AND NOT CYGWIN AND NOT MSYS )
+  # look for headers
+  find_path( GSL_INCLUDE_DIR
+    NAMES gsl/gsl_cdf.h gsl/gsl_randist.h
+    )
+  if( GSL_INCLUDE_DIR )
+    # look for gsl library
+    find_library( GSL_LIBRARY
+      NAMES gsl 
+    )  
+    if( GSL_LIBRARY )
+      set( GSL_INCLUDE_DIRS ${GSL_INCLUDE_DIR} )
+      get_filename_component( GSL_LIBRARY_DIRS ${GSL_LIBRARY} PATH )
+      set( GSL_FOUND ON )
+    endif( GSL_LIBRARY )
+ 
+    # look for gsl cblas library
+    find_library( GSL_CBLAS_LIBRARY
+        NAMES gslcblas 
+      )
+    if( GSL_CBLAS_LIBRARY )
+      set( GSL_CBLAS_FOUND ON )
+    endif( GSL_CBLAS_LIBRARY )
+       
+    set( GSL_LIBRARIES ${GSL_LIBRARY} ${GSL_CBLAS_LIBRARY} )
+  endif( GSL_INCLUDE_DIR )
+   
+  mark_as_advanced(
+    GSL_INCLUDE_DIR
+    GSL_LIBRARY
+    GSL_CBLAS_LIBRARY
+  )
+else( WIN32 AND NOT CYGWIN AND NOT MSYS )
+  if( UNIX OR MSYS )
+    find_program( GSL_CONFIG_EXECUTABLE gsl-config
+      /usr/bin/
+      /usr/local/bin
+    )
+     
+    if( GSL_CONFIG_EXECUTABLE ) 
+      set( GSL_FOUND ON )
+       
+      # run the gsl-config program to get cxxflags
+      execute_process(
+        COMMAND sh "${GSL_CONFIG_EXECUTABLE}" --cflags
+        OUTPUT_VARIABLE GSL_CFLAGS
+        RESULT_VARIABLE RET
+        ERROR_QUIET
+        )
+      if( RET EQUAL 0 )
+        string( STRIP "${GSL_CFLAGS}" GSL_CFLAGS )
+        separate_arguments( GSL_CFLAGS )
+ 
+        # parse definitions from cflags; drop -D* from CFLAGS
+        string( REGEX MATCHALL "-D[^;]+"
+          GSL_DEFINITIONS  "${GSL_CFLAGS}" )
+        string( REGEX REPLACE "-D[^;]+;" ""
+          GSL_CFLAGS "${GSL_CFLAGS}" )
+ 
+        # parse include dirs from cflags; drop -I prefix
+        string( REGEX MATCHALL "-I[^;]+"
+          GSL_INCLUDE_DIRS "${GSL_CFLAGS}" )
+        string( REPLACE "-I" ""
+          GSL_INCLUDE_DIRS "${GSL_INCLUDE_DIRS}")
+        string( REGEX REPLACE "-I[^;]+;" ""
+          GSL_CFLAGS "${GSL_CFLAGS}")
+ 
+        message("GSL_DEFINITIONS=${GSL_DEFINITIONS}")
+        message("GSL_INCLUDE_DIRS=${GSL_INCLUDE_DIRS}")
+        message("GSL_CFLAGS=${GSL_CFLAGS}")
+      else( RET EQUAL 0 )
+        set( GSL_FOUND FALSE )
+      endif( RET EQUAL 0 )
+ 
+      # run the gsl-config program to get the libs
+      execute_process(
+        COMMAND sh "${GSL_CONFIG_EXECUTABLE}" --libs
+        OUTPUT_VARIABLE GSL_LIBRARIES
+        RESULT_VARIABLE RET
+        ERROR_QUIET
+        )
+      if( RET EQUAL 0 )
+        string(STRIP "${GSL_LIBRARIES}" GSL_LIBRARIES )
+        separate_arguments( GSL_LIBRARIES )
+ 
+        # extract linkdirs (-L) for rpath (i.e., LINK_DIRECTORIES)
+        string( REGEX MATCHALL "-L[^;]+"
+          GSL_LIBRARY_DIRS "${GSL_LIBRARIES}" )
+        string( REPLACE "-L" ""
+          GSL_LIBRARY_DIRS "${GSL_LIBRARY_DIRS}" )
+      else( RET EQUAL 0 )
+        set( GSL_FOUND FALSE )
+      endif( RET EQUAL 0 )
+       
+      MARK_AS_ADVANCED(
+        GSL_CFLAGS
+      )
+      message( STATUS "Using GSL from ${GSL_PREFIX}" )
+    else( GSL_CONFIG_EXECUTABLE )
+      message( STATUS "FindGSL: gsl-config not found.")
+    endif( GSL_CONFIG_EXECUTABLE )
+  endif( UNIX OR MSYS )
+endif( WIN32 AND NOT CYGWIN AND NOT MSYS )
+ 
+if( GSL_FOUND )
+  if( NOT GSL_FIND_QUIETLY )
+    message( STATUS "FindGSL: Found both GSL headers and library" )
+  endif( NOT GSL_FIND_QUIETLY )
+else( GSL_FOUND )
+  if( GSL_FIND_REQUIRED )
+    message( FATAL_ERROR "FindGSL: Could not find GSL headers or library" )
+  endif( GSL_FIND_REQUIRED )
+endif( GSL_FOUND )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,85 @@
+find_package(JPEG)
+if(JPEG_FOUND)
+	include_directories(${JPEG_INCLUDE_DIR})
+	list(APPEND _ccv_libs ${JPEG_LIBRARIES})
+	add_definitions(-DHAVE_LIBJPEG)
+else(JPEG_FOUND)
+	message(STATUS "!!! libjpeg not found. Support for JPEG IO will be disabled.")
+endif(JPEG_FOUND)
+
+find_package(PNG)
+if(PNG_FOUND)
+	add_definitions(-DHAVE_LIBPNG)
+	add_definitions(${PNG_DEFINITIONS})
+	include_directories(${PNG_PNG_INCLUDE_DIR})
+	list(APPEND _ccv_libs ${PNG_LIBRARIES})
+else(PNG_FOUND)
+	message(STATUS "!!! libpng not found. support for PNG IO will be disabled.")
+endif(PNG_FOUND)
+
+find_package(GSL)
+if(GSL_FOUND)
+	add_definitions(-DHAVE_GSL)
+	include_directories(${GSL_INCLUDE_DIRS})
+	list(APPEND _ccv_libs ${GSL_LIBRARIES})
+else(GSL_FOUND)
+	message(STATUS "!!! The GNU scientific library (GSL) not found. Support for it will not be compiled in.")
+endif(GSL_FOUND)
+
+find_package(CBLAS)
+if(CBLAS_FOUND)
+	add_definitions(-DHAVE_CBLAS)
+	include_directories(${CBLAS_INCLUDE_DIRS})
+	list(APPEND _ccv_libs ${CBLAS_LIBRARIES})
+else(CBLAS_FOUND)
+	message(STATUS "!!! The CBLAS library was not found. Support for it will not be compiled in.")
+endif(CBLAS_FOUND)
+
+find_package(FFTW)
+if(FFTW_FOUND)
+	include_directories(${FFTW_INCLUDES})
+	list(APPEND _ccv_libs ${FFTW_LIB} ${FFTWF_LIB})
+	add_definitions(-DHAVE_FFTW3)
+else(FFTW_FOUND)
+	message(STATUS "!!! The FFTW3 library was not found. The kissfft library will be used instead.")
+
+	list(APPEND _fft_sources
+		3rdparty/kissfft/kiss_fft.c
+		3rdparty/kissfft/kissf_fft.c
+		3rdparty/kissfft/kiss_fftr.c
+		3rdparty/kissfft/kissf_fftr.c
+		3rdparty/kissfft/kiss_fftndr.c
+		3rdparty/kissfft/kissf_fftnd.c
+		3rdparty/kissfft/kissf_fftndr.c
+		3rdparty/kissfft/kiss_fftnd.c
+	)
+endif(FFTW_FOUND)
+
+find_package(OpenMP)
+if(OPENMP_FOUND)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+else(OPENMP_FOUND)
+	message(STATUS "!!! Your compiler does not appear to support OpenMP.")
+endif(OPENMP_FOUND)
+
+add_library(ccv
+	ccv_classic.c
+	ccv_memory.c
+	ccv_numeric.c
+	ccv_dpm.c
+	ccv_mser.c
+	ccv_bbf.c
+	ccv_daisy.c
+	ccv_io.c
+	ccv_sift.c
+	ccv_cache.c
+	ccv_util.c
+	ccv_basic.c
+	ccv_algebra.c
+	ccv_swt.c
+
+	3rdparty/sha1/sha1.c
+	${_fft_sources}
+)
+target_link_libraries(ccv ${_ccv_libs})

--- a/lib/ccv_algebra.c
+++ b/lib/ccv_algebra.c
@@ -1,7 +1,11 @@
 #include "ccv.h"
 #include "ccv_internal.h"
 #ifdef HAVE_CBLAS
-#include <cblas.h>
+# ifdef HAVE_GSL
+#  include <gsl/gsl_cblas.h>
+# else
+#  include <cblas.h>
+#endif
 #endif
 
 double ccv_trace(ccv_matrix_t* mat)

--- a/lib/ccv_io.c
+++ b/lib/ccv_io.c
@@ -18,7 +18,8 @@
         // Unsupported platform
     #endif
   #else
-    #include <libpng/png.h>
+    #include <zlib.h>
+    #include <png.h>
   #endif
 #endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(regression)
+add_subdirectory(functional)

--- a/test/functional/CMakeLists.txt
+++ b/test/functional/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(_target algebra.tests util.tests numeric.tests basic.tests memory.tests)
+	add_executable(${_target} ${_target}.c)
+	target_link_libraries(${_target} ccv)
+	add_test(
+		NAME ${_target}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		COMMAND ${_target}
+	)
+endforeach(_target)

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(defects.l0.1.tests defects.l0.1.tests.c)
+target_link_libraries(defects.l0.1.tests ccv)
+add_test(defects.l0.1.tests defects.l0.1.tests)


### PR DESCRIPTION
Hi there. This pull request is to add CMake as a build system. The custom Makefile solution is workable but CMake adds the ability to auto-detect a number of the libraries that one has to manually specify via ./configure at the moment. Similarly it contains logic to automatically handle the C dependencies. Lastly it allows for out-of-tree builds which I find terribly convenient when building for different systems.

I have ported the test system over to CTest which allows all tests to be run via a 'make test' target or a subset matching a regex via 'ctest -R [regex]'. Run 'ctest -V' to see output from the tests.

A couple of the commits here also change some #include statements to match the directories which CMake finds for us rather than hard-coded paths.

If this is of interest, I can add in checks for SSE2, -ffast-math and liblinear but I didn't want to spend too much time on this if the concept of using CMake does not interest you.
