### PR TITLE
swtdetect crashes with libpng

### DIFF
--- a/lib/io/_ccv_io_libpng.c
+++ b/lib/io/_ccv_io_libpng.c
@@ -24,8 +24,10 @@ static void _ccv_read_png_fd(FILE* in, ccv_dense_matrix_t** x, int type)
 		png_set_expand_gray_1_2_4_to_8(png_ptr);
 	if (CCV_GET_CHANNEL(im->type) == CCV_C3)
 		png_set_gray_to_rgb(png_ptr);
-	else if (CCV_GET_CHANNEL(im->type) == CCV_C1)
+	else if (CCV_GET_CHANNEL(im->type) == CCV_C1) {
 		png_set_rgb_to_gray(png_ptr, 1, -1, -1);
+		png_set_strip_16(png_ptr);
+	}
 
 	png_read_update_info(png_ptr, info_ptr);
 

--- a/lib/io/_ccv_io_libpng.c
+++ b/lib/io/_ccv_io_libpng.c
@@ -18,16 +18,15 @@ static void _ccv_read_png_fd(FILE* in, ccv_dense_matrix_t** x, int type)
 		*x = im = ccv_dense_matrix_new((int) height, (int) width, (type) ? type : CCV_8U | (((color_type & PNG_COLOR_MASK_COLOR) == PNG_COLOR_TYPE_GRAY) ? CCV_C1 : CCV_C3), 0, 0);
 
 	png_set_strip_alpha(png_ptr);
+	png_set_strip_16(png_ptr);
 	if (color_type == PNG_COLOR_TYPE_PALETTE)
 		png_set_palette_to_rgb(png_ptr);
 	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
 		png_set_expand_gray_1_2_4_to_8(png_ptr);
 	if (CCV_GET_CHANNEL(im->type) == CCV_C3)
 		png_set_gray_to_rgb(png_ptr);
-	else if (CCV_GET_CHANNEL(im->type) == CCV_C1) {
+	else if (CCV_GET_CHANNEL(im->type) == CCV_C1)
 		png_set_rgb_to_gray(png_ptr, 1, -1, -1);
-		png_set_strip_16(png_ptr);
-	}
 
 	png_read_update_info(png_ptr, info_ptr);
 


### PR DESCRIPTION
When I tried to use `swtdetect` on png images with `libpng`, it crashed with the following message.

```
*** glibc detected *** swtdetect: double free or corruption (out): 0x0000000001f7afc0 ***
======= Backtrace: =========
/usr/lib/libc.so.6(+0x798a6)[0x7f02eafed8a6]
/usr/lib/libpng12.so.0(+0x14c39)[0x7f02ec491c39]
/usr/lib/libpng12.so.0(png_destroy_read_struct+0x7e)[0x7f02ec49209e]
swtdetect[0x405efb]
swtdetect[0x40520b]
swtdetect[0x4042ff]
swtdetect[0x402135]
/usr/lib/libc.so.6(__libc_start_main+0xf5)[0x7f02eaf95725]
swtdetect[0x401fe9]
======= Memory map: ========
00400000-0051e000 r-xp 00000000 08:04 1659294                            swtdetect
0051e000-0051f000 rw-p 0011e000 08:04 1659294                            swtdetect
0051f000-0055f000 rw-p 00000000 00:00 0 
01f5f000-01fa4000 rw-p 00000000 00:00 0                                  [heap]
7f02e9f97000-7f02e9fae000 r-xp 00000000 08:02 5947632                    /usr/lib/libpthread-2.16.so
7f02e9fae000-7f02ea1ad000 ---p 00017000 08:02 5947632                    /usr/lib/libpthread-2.16.so
7f02ea1ad000-7f02ea1ae000 r--p 00016000 08:02 5947632                    /usr/lib/libpthread-2.16.so
7f02ea1ae000-7f02ea1af000 rw-p 00017000 08:02 5947632                    /usr/lib/libpthread-2.16.so
7f02ea1af000-7f02ea1b3000 rw-p 00000000 00:00 0 
7f02ea1b3000-7f02ea854000 r-xp 00000000 08:02 2151298                    /usr/lib/libatlas.so
7f02ea854000-7f02eaa53000 ---p 006a1000 08:02 2151298                    /usr/lib/libatlas.so
7f02eaa53000-7f02eaa5c000 rw-p 006a0000 08:02 2151298                    /usr/lib/libatlas.so
7f02eaa5c000-7f02eaa71000 r-xp 00000000 08:02 5949700                    /usr/lib/libgcc_s.so.1
7f02eaa71000-7f02eac70000 ---p 00015000 08:02 5949700                    /usr/lib/libgcc_s.so.1
7f02eac70000-7f02eac71000 rw-p 00014000 08:02 5949700                    /usr/lib/libgcc_s.so.1
7f02eac71000-7f02ead56000 r-xp 00000000 08:02 5949688                    /usr/lib/libstdc++.so.6.0.17
7f02ead56000-7f02eaf55000 ---p 000e5000 08:02 5949688                    /usr/lib/libstdc++.so.6.0.17
7f02eaf55000-7f02eaf5d000 r--p 000e4000 08:02 5949688                    /usr/lib/libstdc++.so.6.0.17
7f02eaf5d000-7f02eaf5f000 rw-p 000ec000 08:02 5949688                    /usr/lib/libstdc++.so.6.0.17
7f02eaf5f000-7f02eaf74000 rw-p 00000000 00:00 0 
7f02eaf74000-7f02eb112000 r-xp 00000000 08:02 5947625                    /usr/lib/libc-2.16.so
7f02eb112000-7f02eb311000 ---p 0019e000 08:02 5947625                    /usr/lib/libc-2.16.so
7f02eb311000-7f02eb315000 r--p 0019d000 08:02 5947625                    /usr/lib/libc-2.16.so
7f02eb315000-7f02eb317000 rw-p 001a1000 08:02 5947625                    /usr/lib/libc-2.16.so
7f02eb317000-7f02eb31b000 rw-p 00000000 00:00 0 
7f02eb31b000-7f02eb33c000 r-xp 00000000 08:02 2151301                    /usr/lib/libptcblas.so
7f02eb33c000-7f02eb53b000 ---p 00021000 08:02 2151301                    /usr/lib/libptcblas.so
7f02eb53b000-7f02eb53c000 rw-p 00020000 08:02 2151301                    /usr/lib/libptcblas.so
7f02eb53c000-7f02eb54a000 r-xp 00000000 08:02 2151312                    /usr/lib/liblinear.so.1
7f02eb54a000-7f02eb74a000 ---p 0000e000 08:02 2151312                    /usr/lib/liblinear.so.1
7f02eb74a000-7f02eb74b000 rw-p 0000e000 08:02 2151312                    /usr/lib/liblinear.so.1
7f02eb74b000-7f02eb8bb000 r-xp 00000000 08:02 2151284                    /usr/lib/libfftw3.so.3.3.2
7f02eb8bb000-7f02ebaba000 ---p 00170000 08:02 2151284                    /usr/lib/libfftw3.so.3.3.2
7f02ebaba000-7f02ebac6000 r--p 0016f000 08:02 2151284                    /usr/lib/libfftw3.so.3.3.2
7f02ebac6000-7f02ebac7000 rw-p 0017b000 08:02 2151284                    /usr/lib/libfftw3.so.3.3.2
7f02ebac7000-7f02ebc2f000 r-xp 00000000 08:02 2151280                    /usr/lib/libfftw3f.so.3.3.2
7f02ebc2f000-7f02ebe2e000 ---p 00168000 08:02 2151280                    /usr/lib/libfftw3f.so.3.3.2
7f02ebe2e000-7f02ebe3a000 r--p 00167000 08:02 2151280                    /usr/lib/libfftw3f.so.3.3.2
7f02ebe3a000-7f02ebe3b000 rw-p 00173000 08:02 2151280                    /usr/lib/libfftw3f.so.3.3.2
7f02ebe3b000-7f02ec054000 r-xp 00000000 08:02 2151267                    /usr/lib/libgsl.so.0.16.0
7f02ec054000-7f02ec254000 ---p 00219000 08:02 2151267                    /usr/lib/libgsl.so.0.16.0
7f02ec254000-7f02ec267000 rw-p 00219000 08:02 2151267                    /usr/lib/libgsl.so.0.16.0
7f02ec267000-7f02ec27c000 r-xp 00000000 08:02 5949735                    /usr/lib/libz.so.1.2.7
7f02ec27c000-7f02ec47b000 ---p 00015000 08:02 5949735                    /usr/lib/libz.so.1.2.7
7f02ec47b000-7f02ec47c000 r--p 00014000 08:02 5949735                    /usr/lib/libz.so.1.2.7
7f02ec47c000-7f02ec47d000 rw-p 00015000 08:02 5949735                    /usr/lib/libz.so.1.2.7
7f02ec47d000-7f02ec4a6000 r-xp 00000000 08:02 2146393                    /usr/lib/libpng12.so.0.50.0
7f02ec4a6000-7f02ec6a5000 ---p 00029000 08:02 2146393                    /usr/lib/libpng12.so.0.50.0
7f02ec6a5000-7f02ec6a6000 r--p 00028000 08:02 2146393                    /usr/lib/libpng12.so.0.50.0
7f02ec6a6000-7f02ec6a7000 rw-p 00029000 08:02 2146393                    /usr/lib/libpng12.so.0.50.0
7f02ec6a7000-7f02ec6e6000 r-xp 00000000 08:02 2146749                    /usr/lib/libjpeg.so.8.0.2
7f02ec6e6000-7f02ec8e6000 ---p 0003f000 08:02 2146749                    /usr/lib/libjpeg.so.8.0.2
7f02ec8e6000-7f02ec8e7000 r--p 0003f000 08:02 2146749                    /usr/lib/libjpeg.so.8.0.2
7f02ec8e7000-7f02ec8e8000 rw-p 00040000 08:02 2146749                    /usr/lib/libjpeg.so.8.0.2
7f02ec8e8000-7f02ec8f8000 rw-p 00000000 00:00 0 
7f02ec8f8000-7f02ec9f1000 r-xp 00000000 08:02 5947607                    /usr/lib/libm-2.16.so
7f02ec9f1000-7f02ecbf0000 ---p 000f9000 08:02 5947607                    /usr/lib/libm-2.16.so
7f02ecbf0000-7f02ecbf1000 r--p 000f8000 08:02 5947607                    /usr/lib/libm-2.16.so
7f02ecbf1000-7f02ecbf2000 rw-p 000f9000 08:02 5947607                    /usr/lib/libm-2.16.so
7f02ecbf2000-7f02ecc13000 r-xp 00000000 08:02 5950638                    /usr/lib/ld-2.16.so
7f02ecdf1000-7f02ecdfb000 rw-p 00000000 00:00 0 
7f02ece11000-7f02ece13000 rw-p 00000000 00:00 0 
7f02ece13000-7f02ece14000 r--p 00021000 08:02 5950638                    /usr/lib/ld-2.16.so
7f02ece14000-7f02ece15000 rw-p 00022000 08:02 5950638                    /usr/lib/ld-2.16.so
7f02ece15000-7f02ece16000 rw-p 00000000 00:00 0 
7fffdce37000-7fffdce58000 rw-p 00000000 00:00 0                          [stack]
7fffdcfff000-7fffdd000000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
[1]    5024 abort      swtdetect 
```

The issue is that after calling `png_set_rgb_to_gray`, the bits depth will not change. Therefore the image data can not fit in a matrix of `CCV_U8`. 

To fix this, just strip bits depth to 8, after converting the image RGB to grayscale.
