### PR TITLE
Fixes a compiler error due to the fact that __thread is not supported on iOS.

### DIFF
--- a/lib/ccv_memory.c
+++ b/lib/ccv_memory.c
@@ -2,6 +2,15 @@
 #include "ccv_internal.h"
 #include "3rdparty/sha1/sha1.h"
 
+#ifdef __APPLE__
+#include "TargetConditionals.h"
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+// Temporary fix: __thread is not supported on iOS so define it to nothing.
+#define __thread
+#endif
+#endif
+
+
 static __thread ccv_cache_t ccv_cache;
 
 /**


### PR DESCRIPTION
I defined away __thread when compiling for iOS.
