### PR TITLE
Fix changing cache signatures

### DIFF
--- a/lib/ccv_basic.c
+++ b/lib/ccv_basic.c
@@ -3,9 +3,10 @@
 
 /* sobel filter is fundamental to many other high-level algorithms,
  * here includes 2 special case impl (for 1x3/3x1, 3x3) and one general impl */
+
 void ccv_sobel(ccv_dense_matrix_t* a, ccv_dense_matrix_t** b, int type, int dx, int dy)
 {
-	ccv_declare_derived_signature(sig, a->sig != 0, ccv_sign_with_format(64, "ccv_sobel(%d,%d)", dx, dy), a->sig, 0);
+	ccv_declare_derived_signature(sig, a->sig != 0, ccv_sign_with_format(64, "ccv_sobel(%d,%d)", dx, dy), a->sig, (uint64_t)0);
 	type = (type == 0) ? CCV_32S | CCV_GET_CHANNEL(a->type) : CCV_GET_DATA_TYPE(type) | CCV_GET_CHANNEL(a->type);
 	ccv_dense_matrix_t* db = *b = ccv_dense_matrix_renew(*b, a->rows, a->cols, CCV_GET_CHANNEL(a->type) | CCV_ALL_DATA_TYPE, type, sig);
 	ccv_object_return_if_cached(, db);
@@ -322,9 +323,9 @@ void ccv_flip(ccv_dense_matrix_t* a, ccv_dense_matrix_t** b, int btype, int type
 	/* this is the special case where ccv_declare_derived_signature_* macros cannot handle properly */
 	uint64_t sig = a->sig;
 	if (type & CCV_FLIP_Y)
-		sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature("ccv_flip_y", 10, sig, 0);
+		sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature("ccv_flip_y", 10, sig, (uint64_t)0);
 	if (type & CCV_FLIP_X)
-		sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature("ccv_flip_x", 10, sig, 0);
+		sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature("ccv_flip_x", 10, sig, (uint64_t)0);
 	ccv_dense_matrix_t* db;
 	if (b == 0)
 	{
@@ -332,7 +333,7 @@ void ccv_flip(ccv_dense_matrix_t* a, ccv_dense_matrix_t** b, int btype, int type
 		if (a->sig != 0)
 		{
 			btype = CCV_GET_DATA_TYPE(a->type) | CCV_GET_CHANNEL(a->type);
-			sig = ccv_cache_generate_signature((const char*)&btype, sizeof(int), sig, 0);
+			sig = ccv_cache_generate_signature((const char*)&btype, sizeof(int), sig, (uint64_t)0);
 			a->sig = sig;
 		}
 	} else {

--- a/lib/ccv_daisy.c
+++ b/lib/ccv_daisy.c
@@ -52,7 +52,7 @@ void ccv_daisy(ccv_dense_matrix_t* a, ccv_dense_matrix_t** b, int type, ccv_dais
 	memset(identifier, 0, ccv_max(sizeof(ccv_daisy_param_t) + 9, sizeof(double) * params.rad_q_no));
 	memcpy(identifier, "ccv_daisy", 9);
 	memcpy(identifier + 9, &params, sizeof(ccv_daisy_param_t));
-	uint64_t sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature(identifier, sizeof(ccv_daisy_param_t) + 9, a->sig, 0);
+	uint64_t sig = (a->sig == 0) ? 0 : ccv_cache_generate_signature(identifier, sizeof(ccv_daisy_param_t) + 9, a->sig, (uint64_t)0);
 	type = (type == 0) ? CCV_32F | CCV_C1 : CCV_GET_DATA_TYPE(type) | CCV_C1;
 	ccv_dense_matrix_t* db = *b = ccv_dense_matrix_renew(*b, a->rows, a->cols * desc_size, CCV_C1 | CCV_ALL_DATA_TYPE, type, sig);
 	int layer_size = a->rows * a->cols;

--- a/lib/ccv_memory.c
+++ b/lib/ccv_memory.c
@@ -63,15 +63,18 @@ ccv_dense_matrix_t* ccv_dense_matrix_renew(ccv_dense_matrix_t* x, int rows, int 
 		assert(x->rows == rows && x->cols == cols && (CCV_GET_DATA_TYPE(x->type) & types) && (CCV_GET_CHANNEL(x->type) == CCV_GET_CHANNEL(types)));
 		prefer_type = CCV_GET_DATA_TYPE(x->type) | CCV_GET_CHANNEL(x->type);
 	}
-	if (sig != 0)
+	if (sig == 0)
+    {
 		sig = ccv_cache_generate_signature((const char*)&prefer_type, sizeof(int), sig, 0);
-	if (x == 0)
-	{
-		x = ccv_dense_matrix_new(rows, cols, prefer_type, 0, sig);
-	} else {
-		x->sig = sig;
-	}
-	return x;
+    }
+    if (x == 0)
+    {
+        x = ccv_dense_matrix_new(rows, cols, prefer_type, 0, sig);
+    } else {
+        x->sig = sig;
+    }
+
+    return x;
 }
 
 void ccv_make_matrix_mutable(ccv_matrix_t* mat)

--- a/lib/ccv_memory.c
+++ b/lib/ccv_memory.c
@@ -65,7 +65,7 @@ ccv_dense_matrix_t* ccv_dense_matrix_renew(ccv_dense_matrix_t* x, int rows, int 
 	}
 	if (sig == 0)
     {
-		sig = ccv_cache_generate_signature((const char*)&prefer_type, sizeof(int), sig, 0);
+		sig = ccv_cache_generate_signature((const char*)&prefer_type, sizeof(int), (uint64_t)0);
     }
     if (x == 0)
     {
@@ -98,7 +98,7 @@ void ccv_make_matrix_immutable(ccv_matrix_t* mat)
 		/* immutable matrix made this way is not reusable (collected), because its signature
 		 * only depends on the content, not the operation to generate it */
 		dmt->type &= ~CCV_REUSABLE;
-		dmt->sig = ccv_cache_generate_signature((char*)dmt->data.u8, dmt->rows * dmt->step, (uint64_t)dmt->type, 0);
+		dmt->sig = ccv_cache_generate_signature((char*)dmt->data.u8, dmt->rows * dmt->step, (uint64_t)dmt->type, (uint64_t)0);
 	}
 }
 
@@ -256,7 +256,7 @@ void ccv_make_array_immutable(ccv_array_t* array)
 	assert(array->sig == 0);
 	array->type &= ~CCV_REUSABLE;
 	/* TODO: trim the array */
-	array->sig = ccv_cache_generate_signature(array->data, array->size * array->rsize, (uint64_t)array->rsize, 0);
+	array->sig = ccv_cache_generate_signature(array->data, array->size * array->rsize, (uint64_t)array->rsize, (uint64_t)0);
 }
 
 void ccv_array_free_immediately(ccv_array_t* array)

--- a/lib/ccv_mser.c
+++ b/lib/ccv_mser.c
@@ -851,7 +851,7 @@ static void _ccv_linear_mser(ccv_dense_matrix_t* a, ccv_dense_matrix_t* h, ccv_d
 
 ccv_array_t* ccv_mser(ccv_dense_matrix_t* a, ccv_dense_matrix_t* h, ccv_dense_matrix_t** b, int type, ccv_mser_param_t params)
 {
-	uint64_t psig = ccv_cache_generate_signature((const char*)&params, sizeof(params), 0);
+	uint64_t psig = ccv_cache_generate_signature((const char*)&params, sizeof(params), (uint64_t)0);
 	ccv_declare_derived_signature_case(bsig, ccv_sign_with_literal("ccv_mser(matrix)"), ccv_sign_if(h == 0 && a->sig != 0, psig, a->sig, 0), ccv_sign_if(h != 0 && a->sig != 0 && h->sig != 0, psig, a->sig, h->sig, 0));
 	ccv_declare_derived_signature_case(rsig, ccv_sign_with_literal("ccv_mser(array)"), ccv_sign_if(h == 0 && a->sig != 0, psig, a->sig, 0), ccv_sign_if(h != 0 && a->sig != 0 && h->sig != 0, psig, a->sig, h->sig, 0));
 	type = (type == 0) ? CCV_32S | CCV_C1 : CCV_GET_DATA_TYPE(type) | CCV_C1;


### PR DESCRIPTION
Completely fixed cache failures that cropped up when compiling for iOS with LLVM. Other platforms were probably getting lucky. The problem was that ccv_cache_generate_signature() takes varargs at the end and makes the assumption that they are all of type uint64_t. The convention is to place a 0 as the last of the varargs to indicate the end however the compiler was generating an int sized 0. Therefore the value likely contained garbage and appended random data that corrupted the hash. The fix was to cast the ending zero as type uint64_t.
