### PR TITLE
Fixing cblas.h's include path on OS X

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -95,6 +95,9 @@ else
 	[nN]* ) ;;
 	*	  ) CFLAGS="$CFLAGS-D HAVE_CBLAS "
 			LDFLAGS="$LDFLAGS-lblas "
+      if [[ $IS_OSX ]] ; then
+        CFLAGS="$CFLAGS-I/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers/ "
+      fi
 			;;
 	esac
 	echo -ne "  Use \033[4mopenmp\033[m [y/N] ? "

--- a/lib/makefile
+++ b/lib/makefile
@@ -8,10 +8,16 @@ CFLAGS := -O3 -ffast-math -Wall $(CFLAGS)# -fprofile-arcs -ftest-coverage
 all: libccv.a
 
 clean:
-	rm -f *.o 3rdparty/sha1/*.o 3rdparty/kissfft/*.o 3rdparty/dsfmt/*.o libccv.a
+	rm -f *.o 3rdparty/sha1/*.o 3rdparty/kissfft/*.o 3rdparty/dsfmt/*.o libccv.a libccv.dylib
 
 libccv.a: ccv_cache.o ccv_memory.o 3rdparty/sha1/sha1.o 3rdparty/kissfft/kiss_fft.o 3rdparty/kissfft/kiss_fftnd.o 3rdparty/kissfft/kiss_fftr.o 3rdparty/kissfft/kiss_fftndr.o 3rdparty/kissfft/kissf_fft.o 3rdparty/kissfft/kissf_fftnd.o 3rdparty/kissfft/kissf_fftr.o 3rdparty/kissfft/kissf_fftndr.o 3rdparty/dsfmt/dSFMT.o 3rdparty/sfmt/SFMT.o ccv_io.o ccv_numeric.o ccv_algebra.o ccv_util.o ccv_basic.o ccv_resample.o ccv_transform.o ccv_classic.o ccv_daisy.o ccv_sift.o ccv_bbf.o ccv_mser.o ccv_swt.o ccv_dpm.o ccv_tld.o ccv_ferns.o
 	ar rcs $@ $^
+
+#
+# OS X dylib
+#
+libccv.dylib: *.o 3rdparty/**/*.o
+	$(CC) -dynamiclib $^ -o $@  -current_version 1.0 $(LDFLAGS)
 
 ccv_io.o: ccv_io.c ccv.h ccv_internal.h io/*.c
 	$(CC) $< -o $@ -c $(CFLAGS)


### PR DESCRIPTION
On OS X, cblas.h isn't in the standard include path, it's in `/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers`
