### PR TITLE
alloca.h breaks the build on openbsd/freebsd

### DIFF
--- a/lib/3rdparty/sfmt/SFMT.c
+++ b/lib/3rdparty/sfmt/SFMT.c
@@ -338,7 +338,9 @@ void sfmt_fill_array64(sfmt_t * sfmt, uint64_t *array, int size) {
  * @param size the size of the array
  * @param rsize the size of each record in the array
  */
-#include <alloca.h>
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+    #include <alloca.h>
+#endif
 
 void sfmt_genrand_shuffle(sfmt_t * sfmt, void *array, int size, int rsize) {
 	int i, j;

--- a/lib/ccv.h
+++ b/lib/ccv.h
@@ -15,7 +15,10 @@
 #include <float.h>
 #include <math.h>
 #include <assert.h>
-#include <alloca.h>
+
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+    #include <alloca.h>
+#endif
 
 #define CCV_PI (3.141592653589793)
 #define ccmalloc malloc


### PR DESCRIPTION
with these simple changes I was able to build the static lib successfully on FreeBSD using clang and OpenBSD using gcc-4.9
