### PR TITLE
Escape arguments coming from Ruby scripts

### DIFF
--- a/bin/bbfdraw.rb
+++ b/bin/bbfdraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 2
 
@@ -14,4 +15,4 @@ STDIN.each_line do |line|
 	rect += sprintf("-draw \"rectangle %d,%d %d,%d\" ", x, y, x + width, y + height)
 end
 
-%x[#{sprintf("convert %s -fill none -stroke green -strokewidth 2 %s%s", ARGV[0], rect, ARGV[1])}]
+%x[#{sprintf("convert %s -fill none -stroke green -strokewidth 2 %s%s", Shellwords.escape(ARGV[0]), rect, Shellwords.escape(ARGV[1]) )}]

--- a/bin/cnndraw.rb
+++ b/bin/cnndraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 3
 
@@ -24,4 +25,4 @@ STDIN.each_line do |line|
 	end
 end
 
-%x[#{sprintf("convert %s %s%s", ARGV[1], draw, ARGV[2])}]
+%x[#{sprintf("convert %s %s%s", Shellwords.escape(ARGV[1]), draw, Shellwords.escape(ARGV[2]))}]

--- a/bin/dpmdraw.rb
+++ b/bin/dpmdraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 2
 
@@ -22,4 +23,4 @@ STDIN.each_line do |line|
 	end
 end
 
-%x[#{sprintf("convert %s -fill none -strokewidth 1 %s%s", ARGV[0], rect, ARGV[1])}]
+%x[#{sprintf("convert %s -fill none -strokewidth 1 %s%s", Shellwords.escape(ARGV[0]), rect, Shellwords.escape(ARGV[1]) )}]

--- a/bin/icfdraw.rb
+++ b/bin/icfdraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 2
 
@@ -14,4 +15,4 @@ STDIN.each_line do |line|
 	rect += sprintf("-draw \"rectangle %d,%d %d,%d\" ", x, y, x + width, y + height)
 end
 
-%x[#{sprintf("convert %s -fill none -stroke lime -strokewidth 2 %s%s", ARGV[0], rect, ARGV[1])}]
+%x[#{sprintf("convert %s -fill none -stroke lime -strokewidth 2 %s%s", Shellwords.escape(ARGV[0]), rect, Shellwords.escape(ARGV[1]) )}]

--- a/bin/siftdraw.rb
+++ b/bin/siftdraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 3 or ARGV.length == 4
 matches = File.new("/tmp/matches.txt", "w+") if ARGV.length == 4
@@ -27,13 +28,13 @@ STDIN.each_line do |line|
 end
 
 if matches.nil?
-	%x[#{sprintf("convert %s -extent %dx%d %s", ARGV[0], object_size[:width] + image_size[:width], [object_size[:height], image_size[:height]].max, ARGV[2])}]
-	%x[#{sprintf("composite -gravity southEast %s %s %s", ARGV[1], ARGV[2], ARGV[2])}]
+	%x[#{sprintf("convert %s -extent %dx%d %s", Shellwords.escape(ARGV[0]), object_size[:width] + image_size[:width], [object_size[:height], image_size[:height]].max, Shellwords.escape(ARGV[2]) )}]
+	%x[#{sprintf("composite -gravity southEast %s %s %s", Shellwords.escape(ARGV[1]), Shellwords.escape(ARGV[2]), Shellwords.escape(ARGV[2]) )}]
 	lines = ""
 	pairs.each do |pair|
 		lines += sprintf("-draw \"line %d,%d,%d,%d\" ", pair[:object][:x], pair[:object][:y], pair[:image][:x] + object_size[:width], pair[:image][:y])
 	end
-	%x[convert #{ARGV[2]} -stroke red #{lines}#{ARGV[2]}]
+	%x[convert #{Shellwords.escape(ARGV[2])} -stroke red #{lines}#{ Shellwords.escape(ARGV[2]) }]
 else
 	matches.close
 	output = %x[#{ARGV[3] + " /tmp/matches.txt"}]
@@ -56,5 +57,5 @@ else
 		z = h[2][0] * point[:x] + h[2][1] * point[:y] + h[2][2]
 		frame << {:x => x / z, :y => y / z}
 	end
-	%x[#{sprintf("convert %s -stroke red -strokewidth 3 -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" %s", ARGV[1], frame[0][:x], frame[0][:y], frame[1][:x], frame[1][:y], frame[1][:x], frame[1][:y], frame[2][:x], frame[2][:y], frame[2][:x], frame[2][:y], frame[3][:x], frame[3][:y], frame[3][:x], frame[3][:y], frame[0][:x], frame[0][:y], ARGV[2])}]
+	%x[#{sprintf("convert %s -stroke red -strokewidth 3 -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" -draw \"line %d,%d,%d,%d\" %s", Shellwords.escape(ARGV[1]), frame[0][:x], frame[0][:y], frame[1][:x], frame[1][:y], frame[1][:x], frame[1][:y], frame[2][:x], frame[2][:y], frame[2][:x], frame[2][:y], frame[3][:x], frame[3][:y], frame[3][:x], frame[3][:y], frame[0][:x], frame[0][:y], Shellwords.escape(ARGV[2]) )}]
 end

--- a/bin/swtdraw.rb
+++ b/bin/swtdraw.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'shellwords'
 
 exit unless ARGV.length == 2
 
@@ -14,4 +15,4 @@ STDIN.each_line do |line|
 	rect += sprintf("-draw \"rectangle %d,%d,%d,%d\" ", x, y, x + width, y + height)
 end
 
-%x[#{sprintf("convert %s -fill none -stroke red -strokewidth 3 %s%s", ARGV[0], rect, ARGV[1])}]
+%x[#{sprintf("convert %s -fill none -stroke red -strokewidth 3 %s%s", Shellwords.escape(ARGV[0]), rect, Shellwords.escape(ARGV[1]) )}]


### PR DESCRIPTION
The Ruby scripts did not work for my when I was trying the face detection example. I was doing a few things wrong, but eventually I got it to work. But only with files that didn't have spaces in the file path.

This commit escapes all the arguments being executed by the ruby scripts. Among other issues (safety) this also allows you pass the scripts images with spaces in their file paths.

http://ruby-doc.org/stdlib-2.0.0/libdoc/shellwords/rdoc/Shellwords.html
