### PR TITLE
Add support for NetBSD

### DIFF
--- a/lib/3rdparty/sfmt/SFMT.c
+++ b/lib/3rdparty/sfmt/SFMT.c
@@ -338,7 +338,7 @@ void sfmt_fill_array64(sfmt_t * sfmt, uint64_t *array, int size) {
  * @param size the size of the array
  * @param rsize the size of each record in the array
  */
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
 #include <alloca.h>
 #endif
 

--- a/lib/ccv.h
+++ b/lib/ccv.h
@@ -14,7 +14,7 @@
 #include <float.h>
 #include <math.h>
 #include <assert.h>
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
 #include <alloca.h>
 #endif
 

--- a/lib/ccv_io.c
+++ b/lib/ccv_io.c
@@ -132,7 +132,7 @@ static int _ccv_read_raw(ccv_dense_matrix_t** x, void* data, int type, int rows,
 	return CCV_IO_FINAL;
 }
 
-#if defined(__APPLE__) || defined(BSD)
+#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 typedef struct {
 	char* buffer;
 	fpos_t pos;
@@ -185,7 +185,7 @@ int ccv_read_impl(const void* in, ccv_dense_matrix_t** x, int type, int rows, in
 	} else if (type & CCV_IO_ANY_STREAM) {
 		assert(rows > 8 && cols == 0 && scanline == 0);
 		assert((type & 0xFF) != CCV_IO_DEFLATE_STREAM); // deflate stream (compressed stream) is not supported yet
-#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L || defined(__APPLE__) || defined(BSD)
+#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 		// this is only supported by glibc
 #if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
 		fd = fmemopen((void*)in, (size_t)rows, "rb");


### PR DESCRIPTION
This pull-request adds support for NetBSD.  I have tested it on NetBSD/amd64
-current (actually not so -current, 9.99.17) and then built and run the examples
in the tutorial and `bin/cnnclassify`.

Regarding changes that add NetBSD support:

 - `alloca(3)` is defined in `stdlib.h` and no `alloca.h` header is present in
   NetBSD
 - In `readfn()` and `seekfn()` it's assumed that `fpos_t` is an integer. However,
   that's not the case on NetBSD (`fpos_t` is a struct).