### PR TITLE
layer norm backward

### DIFF
--- a/lib/nnc/cmd/ccv_nnc_cmd.inc
+++ b/lib/nnc/cmd/ccv_nnc_cmd.inc
@@ -1,134 +1,134 @@
 static ccv_nnc_cmd_init_t init_map[] = {
-	{.name = "CCV_NNC_REDUCE_NORM2_FORWARD", .cmd = 0xb3034e16},
-	{.name = "CCV_NNC_REDUCE_NORM2_BACKWARD", .cmd = 0xb3034e17},
-	{.name = "CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD", .cmd = 0x284ed926},
-	{.name = "CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD", .cmd = 0x284ed927},
-	{.name = "CCV_NNC_RELU_FORWARD", .cmd = 0xc51eaa80},
-	{.name = "CCV_NNC_RELU_BACKWARD", .cmd = 0xc51eaa81},
-	{.name = "CCV_NNC_NMS_FORWARD", .cmd = 0xdba26106},
-	{.name = "CCV_NNC_NMS_BACKWARD", .cmd = 0xdba26107},
-	{.name = "CCV_NNC_FORMAT_TRANSFORM_FORWARD", .cmd = 0xe4a2b192},
-	{.name = "CCV_NNC_FORMAT_TRANSFORM_BACKWARD", .cmd = 0xe4a2b193},
-	{.name = "CCV_NNC_DATA_TRANSFER_FORWARD", .cmd = 0x12d21e1a},
-	{.name = "CCV_NNC_DATA_TRANSFER_BACKWARD", .cmd = 0x12d21e1b},
-	{.name = "CCV_NNC_COMM_REDUCE_FORWARD", .cmd = 0x3434ead8},
-	{.name = "CCV_NNC_COMM_REDUCE_BACKWARD", .cmd = 0x3434ead9},
-	{.name = "CCV_NNC_SGD_FORWARD", .cmd = 0xe650ad26},
-	{.name = "CCV_NNC_SGD_BACKWARD", .cmd = 0xe650ad27},
-	{.name = "CCV_NNC_EWDIV_FORWARD", .cmd = 0x1cd2fa18},
-	{.name = "CCV_NNC_EWDIV_BACKWARD", .cmd = 0x1cd2fa19},
-	{.name = "CCV_NNC_MAX_POOL_FORWARD", .cmd = 0x7bec9360},
-	{.name = "CCV_NNC_MAX_POOL_BACKWARD", .cmd = 0x7bec9361},
-	{.name = "CCV_NNC_EWSUM_FORWARD", .cmd = 0xe21a2c4c},
-	{.name = "CCV_NNC_EWSUM_BACKWARD", .cmd = 0xe21a2c4d},
-	{.name = "CCV_NNC_GROUP_NORM_FORWARD", .cmd = 0x17deb074},
-	{.name = "CCV_NNC_GROUP_NORM_BACKWARD", .cmd = 0x17deb075},
-	{.name = "CCV_NNC_EWPROD_FORWARD", .cmd = 0xee07e8fe},
-	{.name = "CCV_NNC_EWPROD_BACKWARD", .cmd = 0xee07e8ff},
-	{.name = "CCV_NNC_SCALAR_MUL_FORWARD", .cmd = 0x8b4d86aa},
-	{.name = "CCV_NNC_SCALAR_MUL_BACKWARD", .cmd = 0x8b4d86ab},
-	{.name = "CCV_NNC_RANDOM_NORMAL_FORWARD", .cmd = 0x7062c8b4},
-	{.name = "CCV_NNC_RANDOM_NORMAL_BACKWARD", .cmd = 0x7062c8b5},
-	{.name = "CCV_NNC_REDUCE_SUM_FORWARD", .cmd = 0x52970f06},
-	{.name = "CCV_NNC_REDUCE_SUM_BACKWARD", .cmd = 0x52970f07},
-	{.name = "CCV_NNC_DROPOUT_FORWARD", .cmd = 0x7f2dc3e4},
-	{.name = "CCV_NNC_DROPOUT_BACKWARD", .cmd = 0x7f2dc3e5},
-	{.name = "CCV_NNC_SWISH_FORWARD", .cmd = 0x583d90c2},
-	{.name = "CCV_NNC_SWISH_BACKWARD", .cmd = 0x583d90c3},
-	{.name = "CCV_NNC_EWSQRT_FORWARD", .cmd = 0x8870a61e},
-	{.name = "CCV_NNC_EWSQRT_BACKWARD", .cmd = 0x8870a61f},
-	{.name = "CCV_NNC_RMSPROP_FORWARD", .cmd = 0x9c886b1c},
-	{.name = "CCV_NNC_RMSPROP_BACKWARD", .cmd = 0x9c886b1d},
-	{.name = "CCV_NNC_MAX_FORWARD", .cmd = 0xdf6f014c},
-	{.name = "CCV_NNC_MAX_BACKWARD", .cmd = 0xdf6f014d},
-	{.name = "CCV_NNC_MUL_FORWARD", .cmd = 0x24721a46},
-	{.name = "CCV_NNC_MUL_BACKWARD", .cmd = 0x24721a47},
-	{.name = "CCV_NNC_SET_FORWARD", .cmd = 0x2b070804},
-	{.name = "CCV_NNC_SET_BACKWARD", .cmd = 0x2b070805},
-	{.name = "CCV_NNC_AVERAGE_POOL_FORWARD", .cmd = 0x51267ab8},
-	{.name = "CCV_NNC_AVERAGE_POOL_BACKWARD", .cmd = 0x51267ab9},
-	{.name = "CCV_NNC_SMOOTH_L1_FORWARD", .cmd = 0x4e428e},
-	{.name = "CCV_NNC_SMOOTH_L1_BACKWARD", .cmd = 0x4e428f},
-	{.name = "CCV_NNC_CONVOLUTION_FORWARD", .cmd = 0x254d05f4},
-	{.name = "CCV_NNC_CONVOLUTION_BACKWARD", .cmd = 0x254d05f5},
-	{.name = "CCV_NNC_MASKED_FILL_FORWARD", .cmd = 0x7f992d84},
-	{.name = "CCV_NNC_MASKED_FILL_BACKWARD", .cmd = 0x7f992d85},
-	{.name = "CCV_NNC_REDUCE_MIN_FORWARD", .cmd = 0x6785ef96},
-	{.name = "CCV_NNC_REDUCE_MIN_BACKWARD", .cmd = 0x6785ef97},
-	{.name = "CCV_NNC_COMPRESSION_LSSC_FORWARD", .cmd = 0x17ea8f72},
-	{.name = "CCV_NNC_COMPRESSION_LSSC_BACKWARD", .cmd = 0x17ea8f73},
-	{.name = "CCV_NNC_GEMM_FORWARD", .cmd = 0x7e87d00c},
-	{.name = "CCV_NNC_GEMM_BACKWARD", .cmd = 0x7e87d00d},
-	{.name = "CCV_NNC_LAMB_FORWARD", .cmd = 0x450edb1a},
-	{.name = "CCV_NNC_LAMB_BACKWARD", .cmd = 0x450edb1b},
 	{.name = "CCV_NNC_SIGMOID_FORWARD", .cmd = 0xf2f69650},
 	{.name = "CCV_NNC_SIGMOID_BACKWARD", .cmd = 0xf2f69651},
-	{.name = "CCV_NNC_ROI_ALIGN_FORWARD", .cmd = 0xfef55168},
-	{.name = "CCV_NNC_ROI_ALIGN_BACKWARD", .cmd = 0xfef55169},
-	{.name = "CCV_NNC_LAYER_NORM_FORWARD", .cmd = 0xbed3c264},
-	{.name = "CCV_NNC_LAYER_NORM_BACKWARD", .cmd = 0xbed3c265},
-	{.name = "CCV_NNC_UPSAMPLE_FORWARD", .cmd = 0x73875556},
-	{.name = "CCV_NNC_UPSAMPLE_BACKWARD", .cmd = 0x73875557},
-	{.name = "CCV_NNC_SOFTMAX_FORWARD", .cmd = 0xc969a252},
-	{.name = "CCV_NNC_SOFTMAX_BACKWARD", .cmd = 0xc969a253},
-	{.name = "CCV_NNC_MIN_FORWARD", .cmd = 0x972fbd26},
-	{.name = "CCV_NNC_MIN_BACKWARD", .cmd = 0x972fbd27},
-	{.name = "CCV_NNC_REDUCE_ISNAN_FORWARD", .cmd = 0xee0a4ade},
-	{.name = "CCV_NNC_REDUCE_ISNAN_BACKWARD", .cmd = 0xee0a4adf},
-	{.name = "CCV_NNC_TRANSPOSE_FORWARD", .cmd = 0xb4d506e0},
-	{.name = "CCV_NNC_TRANSPOSE_BACKWARD", .cmd = 0xb4d506e1},
-	{.name = "CCV_NNC_BINARY_CROSSENTROPY_FORWARD", .cmd = 0xcd2107ec},
-	{.name = "CCV_NNC_BINARY_CROSSENTROPY_BACKWARD", .cmd = 0xcd2107ed},
-	{.name = "CCV_NNC_REDUCE_MAX_FORWARD", .cmd = 0x80f1a506},
-	{.name = "CCV_NNC_REDUCE_MAX_BACKWARD", .cmd = 0x80f1a507},
-	{.name = "CCV_NNC_COMM_ALLREDUCE_FORWARD", .cmd = 0x75c8d340},
-	{.name = "CCV_NNC_COMM_ALLREDUCE_BACKWARD", .cmd = 0x75c8d341},
+	{.name = "CCV_NNC_MAX_POOL_FORWARD", .cmd = 0x7bec9360},
+	{.name = "CCV_NNC_MAX_POOL_BACKWARD", .cmd = 0x7bec9361},
 	{.name = "CCV_NNC_HISTOGRAM_FORWARD", .cmd = 0xc5473e44},
 	{.name = "CCV_NNC_HISTOGRAM_BACKWARD", .cmd = 0xc5473e45},
-	{.name = "CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD", .cmd = 0xd9e0e4a},
-	{.name = "CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD", .cmd = 0xd9e0e4b},
-	{.name = "CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD", .cmd = 0xc26b7b5e},
-	{.name = "CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD", .cmd = 0xc26b7b5f},
-	{.name = "CCV_NNC_GELU_FORWARD", .cmd = 0xb1527ab8},
-	{.name = "CCV_NNC_GELU_BACKWARD", .cmd = 0xb1527ab9},
+	{.name = "CCV_NNC_REDUCE_ISNAN_FORWARD", .cmd = 0xee0a4ade},
+	{.name = "CCV_NNC_REDUCE_ISNAN_BACKWARD", .cmd = 0xee0a4adf},
 	{.name = "CCV_NNC_RANDOM_UNIFORM_FORWARD", .cmd = 0xa0cd1d5e},
 	{.name = "CCV_NNC_RANDOM_UNIFORM_BACKWARD", .cmd = 0xa0cd1d5f},
-	{.name = "CCV_NNC_ARGMAX_FORWARD", .cmd = 0x68af2804},
-	{.name = "CCV_NNC_ARGMAX_BACKWARD", .cmd = 0x68af2805},
-	{.name = "CCV_NNC_ADAMW_FORWARD", .cmd = 0x4f5d4870},
-	{.name = "CCV_NNC_ADAMW_BACKWARD", .cmd = 0x4f5d4871},
-	{.name = "CCV_NNC_REDUCE_MEAN_FORWARD", .cmd = 0xf23556c6},
-	{.name = "CCV_NNC_REDUCE_MEAN_BACKWARD", .cmd = 0xf23556c7},
-	{.name = "CCV_NNC_ARGMIN_FORWARD", .cmd = 0xeb8747f2},
-	{.name = "CCV_NNC_ARGMIN_BACKWARD", .cmd = 0xeb8747f3},
-	{.name = "CCV_NNC_ADAM_FORWARD", .cmd = 0xe30099dc},
-	{.name = "CCV_NNC_ADAM_BACKWARD", .cmd = 0xe30099dd},
-	{.name = "CCV_NNC_EWEXP_FORWARD", .cmd = 0xd784b170},
-	{.name = "CCV_NNC_EWEXP_BACKWARD", .cmd = 0xd784b171},
-	{.name = "CCV_NNC_LEAKY_RELU_FORWARD", .cmd = 0x507144e0},
-	{.name = "CCV_NNC_LEAKY_RELU_BACKWARD", .cmd = 0x507144e1},
-	{.name = "CCV_NNC_EWLOG_FORWARD", .cmd = 0xf4191bf2},
-	{.name = "CCV_NNC_EWLOG_BACKWARD", .cmd = 0xf4191bf3},
-	{.name = "CCV_NNC_TANH_FORWARD", .cmd = 0x6a62be30},
-	{.name = "CCV_NNC_TANH_BACKWARD", .cmd = 0x6a62be31},
-	{.name = "CCV_NNC_COMM_BROADCAST_FORWARD", .cmd = 0x830eee},
-	{.name = "CCV_NNC_COMM_BROADCAST_BACKWARD", .cmd = 0x830eef},
+	{.name = "CCV_NNC_DATA_TRANSFER_FORWARD", .cmd = 0x12d21e1a},
+	{.name = "CCV_NNC_DATA_TRANSFER_BACKWARD", .cmd = 0x12d21e1b},
+	{.name = "CCV_NNC_RELU_FORWARD", .cmd = 0xc51eaa80},
+	{.name = "CCV_NNC_RELU_BACKWARD", .cmd = 0xc51eaa81},
+	{.name = "CCV_NNC_COMM_REDUCE_FORWARD", .cmd = 0x3434ead8},
+	{.name = "CCV_NNC_COMM_REDUCE_BACKWARD", .cmd = 0x3434ead9},
+	{.name = "CCV_NNC_EWDIV_FORWARD", .cmd = 0x1cd2fa18},
+	{.name = "CCV_NNC_EWDIV_BACKWARD", .cmd = 0x1cd2fa19},
+	{.name = "CCV_NNC_DROPOUT_FORWARD", .cmd = 0x7f2dc3e4},
+	{.name = "CCV_NNC_DROPOUT_BACKWARD", .cmd = 0x7f2dc3e5},
 	{.name = "CCV_NNC_MSE_FORWARD", .cmd = 0x6904a9a2},
 	{.name = "CCV_NNC_MSE_BACKWARD", .cmd = 0x6904a9a3},
-	{.name = "CCV_NNC_BATCH_NORM_FORWARD", .cmd = 0x5419819c},
-	{.name = "CCV_NNC_BATCH_NORM_BACKWARD", .cmd = 0x5419819d},
-	{.name = "CCV_NNC_ADD_FORWARD", .cmd = 0x58fb3664},
-	{.name = "CCV_NNC_ADD_BACKWARD", .cmd = 0x58fb3665},
+	{.name = "CCV_NNC_MASKED_FILL_FORWARD", .cmd = 0x7f992d84},
+	{.name = "CCV_NNC_MASKED_FILL_BACKWARD", .cmd = 0x7f992d85},
+	{.name = "CCV_NNC_REDUCE_MEAN_FORWARD", .cmd = 0xf23556c6},
+	{.name = "CCV_NNC_REDUCE_MEAN_BACKWARD", .cmd = 0xf23556c7},
+	{.name = "CCV_NNC_LAMB_FORWARD", .cmd = 0x450edb1a},
+	{.name = "CCV_NNC_LAMB_BACKWARD", .cmd = 0x450edb1b},
+	{.name = "CCV_NNC_MAX_FORWARD", .cmd = 0xdf6f014c},
+	{.name = "CCV_NNC_MAX_BACKWARD", .cmd = 0xdf6f014d},
+	{.name = "CCV_NNC_SMOOTH_L1_FORWARD", .cmd = 0x4e428e},
+	{.name = "CCV_NNC_SMOOTH_L1_BACKWARD", .cmd = 0x4e428f},
+	{.name = "CCV_NNC_BINARY_CROSSENTROPY_FORWARD", .cmd = 0xcd2107ec},
+	{.name = "CCV_NNC_BINARY_CROSSENTROPY_BACKWARD", .cmd = 0xcd2107ed},
 	{.name = "CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD", .cmd = 0x1eb327a2},
 	{.name = "CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD", .cmd = 0x1eb327a3},
-	{.name = "CCV_NNC_LSTM_FORWARD", .cmd = 0xc5cb998c},
-	{.name = "CCV_NNC_LSTM_BACKWARD", .cmd = 0xc5cb998d},
-	{.name = "CCV_NNC_CLAMP_FORWARD", .cmd = 0x2640d854},
-	{.name = "CCV_NNC_CLAMP_BACKWARD", .cmd = 0x2640d855},
-	{.name = "CCV_NNC_INDEX_SELECT_FORWARD", .cmd = 0x7ee7771e},
-	{.name = "CCV_NNC_INDEX_SELECT_BACKWARD", .cmd = 0x7ee7771f},
+	{.name = "CCV_NNC_RMSPROP_FORWARD", .cmd = 0x9c886b1c},
+	{.name = "CCV_NNC_RMSPROP_BACKWARD", .cmd = 0x9c886b1d},
+	{.name = "CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD", .cmd = 0x284ed926},
+	{.name = "CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD", .cmd = 0x284ed927},
+	{.name = "CCV_NNC_EWSUM_FORWARD", .cmd = 0xe21a2c4c},
+	{.name = "CCV_NNC_EWSUM_BACKWARD", .cmd = 0xe21a2c4d},
+	{.name = "CCV_NNC_EWEXP_FORWARD", .cmd = 0xd784b170},
+	{.name = "CCV_NNC_EWEXP_BACKWARD", .cmd = 0xd784b171},
+	{.name = "CCV_NNC_ARGMAX_FORWARD", .cmd = 0x68af2804},
+	{.name = "CCV_NNC_ARGMAX_BACKWARD", .cmd = 0x68af2805},
+	{.name = "CCV_NNC_TRANSPOSE_FORWARD", .cmd = 0xb4d506e0},
+	{.name = "CCV_NNC_TRANSPOSE_BACKWARD", .cmd = 0xb4d506e1},
+	{.name = "CCV_NNC_REDUCE_SUM_FORWARD", .cmd = 0x52970f06},
+	{.name = "CCV_NNC_REDUCE_SUM_BACKWARD", .cmd = 0x52970f07},
+	{.name = "CCV_NNC_RANDOM_NORMAL_FORWARD", .cmd = 0x7062c8b4},
+	{.name = "CCV_NNC_RANDOM_NORMAL_BACKWARD", .cmd = 0x7062c8b5},
+	{.name = "CCV_NNC_ADD_FORWARD", .cmd = 0x58fb3664},
+	{.name = "CCV_NNC_ADD_BACKWARD", .cmd = 0x58fb3665},
+	{.name = "CCV_NNC_LAYER_NORM_FORWARD", .cmd = 0xbed3c264},
+	{.name = "CCV_NNC_LAYER_NORM_BACKWARD", .cmd = 0xbed3c265},
+	{.name = "CCV_NNC_FORMAT_TRANSFORM_FORWARD", .cmd = 0xe4a2b192},
+	{.name = "CCV_NNC_FORMAT_TRANSFORM_BACKWARD", .cmd = 0xe4a2b193},
+	{.name = "CCV_NNC_GEMM_FORWARD", .cmd = 0x7e87d00c},
+	{.name = "CCV_NNC_GEMM_BACKWARD", .cmd = 0x7e87d00d},
+	{.name = "CCV_NNC_COMM_BROADCAST_FORWARD", .cmd = 0x830eee},
+	{.name = "CCV_NNC_COMM_BROADCAST_BACKWARD", .cmd = 0x830eef},
+	{.name = "CCV_NNC_COMPRESSION_LSSC_FORWARD", .cmd = 0x17ea8f72},
+	{.name = "CCV_NNC_COMPRESSION_LSSC_BACKWARD", .cmd = 0x17ea8f73},
+	{.name = "CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD", .cmd = 0xc26b7b5e},
+	{.name = "CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD", .cmd = 0xc26b7b5f},
+	{.name = "CCV_NNC_MIN_FORWARD", .cmd = 0x972fbd26},
+	{.name = "CCV_NNC_MIN_BACKWARD", .cmd = 0x972fbd27},
+	{.name = "CCV_NNC_MUL_FORWARD", .cmd = 0x24721a46},
+	{.name = "CCV_NNC_MUL_BACKWARD", .cmd = 0x24721a47},
+	{.name = "CCV_NNC_GROUP_NORM_FORWARD", .cmd = 0x17deb074},
+	{.name = "CCV_NNC_GROUP_NORM_BACKWARD", .cmd = 0x17deb075},
+	{.name = "CCV_NNC_SET_FORWARD", .cmd = 0x2b070804},
+	{.name = "CCV_NNC_SET_BACKWARD", .cmd = 0x2b070805},
 	{.name = "CCV_NNC_DATATYPE_CONVERSION_FORWARD", .cmd = 0xd873e38c},
 	{.name = "CCV_NNC_DATATYPE_CONVERSION_BACKWARD", .cmd = 0xd873e38d},
+	{.name = "CCV_NNC_INDEX_SELECT_FORWARD", .cmd = 0x7ee7771e},
+	{.name = "CCV_NNC_INDEX_SELECT_BACKWARD", .cmd = 0x7ee7771f},
+	{.name = "CCV_NNC_ARGMIN_FORWARD", .cmd = 0xeb8747f2},
+	{.name = "CCV_NNC_ARGMIN_BACKWARD", .cmd = 0xeb8747f3},
+	{.name = "CCV_NNC_GELU_FORWARD", .cmd = 0xb1527ab8},
+	{.name = "CCV_NNC_GELU_BACKWARD", .cmd = 0xb1527ab9},
+	{.name = "CCV_NNC_ADAMW_FORWARD", .cmd = 0x4f5d4870},
+	{.name = "CCV_NNC_ADAMW_BACKWARD", .cmd = 0x4f5d4871},
+	{.name = "CCV_NNC_NMS_FORWARD", .cmd = 0xdba26106},
+	{.name = "CCV_NNC_NMS_BACKWARD", .cmd = 0xdba26107},
+	{.name = "CCV_NNC_UPSAMPLE_FORWARD", .cmd = 0x73875556},
+	{.name = "CCV_NNC_UPSAMPLE_BACKWARD", .cmd = 0x73875557},
+	{.name = "CCV_NNC_LSTM_FORWARD", .cmd = 0xc5cb998c},
+	{.name = "CCV_NNC_LSTM_BACKWARD", .cmd = 0xc5cb998d},
+	{.name = "CCV_NNC_AVERAGE_POOL_FORWARD", .cmd = 0x51267ab8},
+	{.name = "CCV_NNC_AVERAGE_POOL_BACKWARD", .cmd = 0x51267ab9},
+	{.name = "CCV_NNC_TANH_FORWARD", .cmd = 0x6a62be30},
+	{.name = "CCV_NNC_TANH_BACKWARD", .cmd = 0x6a62be31},
+	{.name = "CCV_NNC_COMM_ALLREDUCE_FORWARD", .cmd = 0x75c8d340},
+	{.name = "CCV_NNC_COMM_ALLREDUCE_BACKWARD", .cmd = 0x75c8d341},
+	{.name = "CCV_NNC_EWPROD_FORWARD", .cmd = 0xee07e8fe},
+	{.name = "CCV_NNC_EWPROD_BACKWARD", .cmd = 0xee07e8ff},
+	{.name = "CCV_NNC_CLAMP_FORWARD", .cmd = 0x2640d854},
+	{.name = "CCV_NNC_CLAMP_BACKWARD", .cmd = 0x2640d855},
+	{.name = "CCV_NNC_ADAM_FORWARD", .cmd = 0xe30099dc},
+	{.name = "CCV_NNC_ADAM_BACKWARD", .cmd = 0xe30099dd},
+	{.name = "CCV_NNC_BATCH_NORM_FORWARD", .cmd = 0x5419819c},
+	{.name = "CCV_NNC_BATCH_NORM_BACKWARD", .cmd = 0x5419819d},
+	{.name = "CCV_NNC_CONVOLUTION_FORWARD", .cmd = 0x254d05f4},
+	{.name = "CCV_NNC_CONVOLUTION_BACKWARD", .cmd = 0x254d05f5},
+	{.name = "CCV_NNC_REDUCE_MAX_FORWARD", .cmd = 0x80f1a506},
+	{.name = "CCV_NNC_REDUCE_MAX_BACKWARD", .cmd = 0x80f1a507},
+	{.name = "CCV_NNC_REDUCE_NORM2_FORWARD", .cmd = 0xb3034e16},
+	{.name = "CCV_NNC_REDUCE_NORM2_BACKWARD", .cmd = 0xb3034e17},
+	{.name = "CCV_NNC_ROI_ALIGN_FORWARD", .cmd = 0xfef55168},
+	{.name = "CCV_NNC_ROI_ALIGN_BACKWARD", .cmd = 0xfef55169},
+	{.name = "CCV_NNC_REDUCE_MIN_FORWARD", .cmd = 0x6785ef96},
+	{.name = "CCV_NNC_REDUCE_MIN_BACKWARD", .cmd = 0x6785ef97},
+	{.name = "CCV_NNC_SOFTMAX_FORWARD", .cmd = 0xc969a252},
+	{.name = "CCV_NNC_SOFTMAX_BACKWARD", .cmd = 0xc969a253},
+	{.name = "CCV_NNC_EWLOG_FORWARD", .cmd = 0xf4191bf2},
+	{.name = "CCV_NNC_EWLOG_BACKWARD", .cmd = 0xf4191bf3},
+	{.name = "CCV_NNC_LEAKY_RELU_FORWARD", .cmd = 0x507144e0},
+	{.name = "CCV_NNC_LEAKY_RELU_BACKWARD", .cmd = 0x507144e1},
+	{.name = "CCV_NNC_EWSQRT_FORWARD", .cmd = 0x8870a61e},
+	{.name = "CCV_NNC_EWSQRT_BACKWARD", .cmd = 0x8870a61f},
+	{.name = "CCV_NNC_SWISH_FORWARD", .cmd = 0x583d90c2},
+	{.name = "CCV_NNC_SWISH_BACKWARD", .cmd = 0x583d90c3},
+	{.name = "CCV_NNC_SCALAR_MUL_FORWARD", .cmd = 0x8b4d86aa},
+	{.name = "CCV_NNC_SCALAR_MUL_BACKWARD", .cmd = 0x8b4d86ab},
+	{.name = "CCV_NNC_SGD_FORWARD", .cmd = 0xe650ad26},
+	{.name = "CCV_NNC_SGD_BACKWARD", .cmd = 0xe650ad27},
+	{.name = "CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD", .cmd = 0xd9e0e4a},
+	{.name = "CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD", .cmd = 0xd9e0e4b},
 };
 
 static ccv_nnc_cmd_backend_init_t backend_init_map[] = {
@@ -143,29 +143,29 @@ static ccv_nnc_cmd_backend_init_t backend_init_map[] = {
 
 static inline int _ccv_nnc_cmd_ph(const uint32_t cmd)
 {
-	switch ((cmd >> 6) % 10)
+	switch ((cmd >> 17) % 10)
 	{
 		case 0:
-			return ((((cmd >> 5) % 7) + 0) << 1) | (cmd & 1);
+			return ((((cmd >> 6) % 11) + 53) << 1) | (cmd & 1);
 		case 1:
-			return ((((cmd >> 1) % 39) + 5) << 1) | (cmd & 1);
+			return ((((cmd >> 5) % 38) + 2) << 1) | (cmd & 1);
 		case 2:
-			return ((((cmd >> 1) % 28) + 0) << 1) | (cmd & 1);
+			return ((((cmd >> 1) % 15) + 0) << 1) | (cmd & 1);
 		case 3:
-			return ((((cmd >> 6) % 33) + 31) << 1) | (cmd & 1);
+			return ((((cmd >> 1) % 38) + 27) << 1) | (cmd & 1);
 		case 4:
-			return ((((cmd >> 20) % 8) + 57) << 1) | (cmd & 1);
+			return ((((cmd >> 2) % 11) + 51) << 1) | (cmd & 1);
 		case 5:
-			return ((((cmd >> 3) % 22) + 1) << 1) | (cmd & 1);
+			return ((((cmd >> 1) % 14) + 25) << 1) | (cmd & 1);
 		case 6:
-			return ((((cmd >> 1) % 46) + 13) << 1) | (cmd & 1);
+			return ((((cmd >> 3) % 52) + 11) << 1) | (cmd & 1);
 		case 7:
-			return ((((cmd >> 1) % 17) + 40) << 1) | (cmd & 1);
+			return ((((cmd >> 1) % 15) + 35) << 1) | (cmd & 1);
 		case 8:
-			return ((((cmd >> 1) % 20) + 21) << 1) | (cmd & 1);
+			return ((((cmd >> 12) % 40) + 5) << 1) | (cmd & 1);
 		case 9:
 		default:
-			return ((((cmd >> 2) % 22) + 24) << 1) | (cmd & 1);
+			return ((((cmd >> 1) % 28) + 0) << 1) | (cmd & 1);
 	}
 }
 
@@ -179,136 +179,136 @@ static inline int _ccv_nnc_cmd_backend_ph(const uint32_t backend)
 	}
 }
 
-void _register_command_CCV_NNC_REDUCE_NORM2_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_NORM2_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_NMS_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_NMS_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_DATA_TRANSFER_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_DATA_TRANSFER_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_REDUCE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_REDUCE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SGD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SGD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWDIV_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWDIV_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MAX_POOL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MAX_POOL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWSUM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWSUM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GROUP_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GROUP_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWPROD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWPROD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SCALAR_MUL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SCALAR_MUL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RANDOM_NORMAL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_SUM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_SUM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_DROPOUT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_DROPOUT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SWISH_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SWISH_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWSQRT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWSQRT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RMSPROP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_RMSPROP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MUL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MUL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SET_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SET_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_AVERAGE_POOL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_AVERAGE_POOL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SMOOTH_L1_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SMOOTH_L1_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_CONVOLUTION_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_CONVOLUTION_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MASKED_FILL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MASKED_FILL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GEMM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GEMM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LAMB_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LAMB_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_SIGMOID_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_SIGMOID_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ROI_ALIGN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ROI_ALIGN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LAYER_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LAYER_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_UPSAMPLE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_UPSAMPLE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SOFTMAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SOFTMAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_MIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_ISNAN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_TRANSPOSE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_TRANSPOSE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MAX_POOL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MAX_POOL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_HISTOGRAM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_HISTOGRAM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_GELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_ISNAN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ARGMAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ARGMAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADAMW_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADAMW_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MEAN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_REDUCE_MEAN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ARGMIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ARGMIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADAM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADAM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWEXP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWEXP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LEAKY_RELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LEAKY_RELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWLOG_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_EWLOG_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_TANH_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_TANH_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_BROADCAST_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_COMM_BROADCAST_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_DATA_TRANSFER_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_DATA_TRANSFER_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_REDUCE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_REDUCE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWDIV_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWDIV_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_DROPOUT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_DROPOUT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_MSE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_MSE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_BATCH_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_BATCH_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_ADD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MASKED_FILL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MASKED_FILL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MEAN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MEAN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LAMB_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LAMB_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SMOOTH_L1_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SMOOTH_L1_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LSTM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_LSTM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_CLAMP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_CLAMP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_INDEX_SELECT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
-void _register_command_CCV_NNC_INDEX_SELECT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RMSPROP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RMSPROP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWSUM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWSUM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWEXP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWEXP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ARGMAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ARGMAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_TRANSPOSE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_TRANSPOSE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_SUM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_SUM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RANDOM_NORMAL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LAYER_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LAYER_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GEMM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GEMM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_BROADCAST_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_BROADCAST_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MUL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_MUL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GROUP_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GROUP_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SET_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SET_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD(ccv_nnc_cmd_registry_t* const registry);
 void _register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_INDEX_SELECT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_INDEX_SELECT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ARGMIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ARGMIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_GELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADAMW_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADAMW_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_NMS_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_NMS_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_UPSAMPLE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_UPSAMPLE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LSTM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LSTM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_AVERAGE_POOL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_AVERAGE_POOL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_TANH_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_TANH_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWPROD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWPROD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_CLAMP_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_CLAMP_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADAM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ADAM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_BATCH_NORM_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_BATCH_NORM_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_CONVOLUTION_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_CONVOLUTION_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_NORM2_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_NORM2_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ROI_ALIGN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_ROI_ALIGN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MIN_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_REDUCE_MIN_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SOFTMAX_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SOFTMAX_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWLOG_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWLOG_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LEAKY_RELU_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_LEAKY_RELU_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWSQRT_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_EWSQRT_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SWISH_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SWISH_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SCALAR_MUL_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SCALAR_MUL_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SGD_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SGD_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD(ccv_nnc_cmd_registry_t* const registry);
+void _register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD(ccv_nnc_cmd_registry_t* const registry);
 
 void _register_command_CCV_NNC_ADAM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_ADAM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(ccv_nnc_cmd_backend_registry_t* const registry);
@@ -577,6 +577,7 @@ void _register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(cc
 void _register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
+void _register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
 void _register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(ccv_nnc_cmd_backend_registry_t* const registry);
@@ -610,432 +611,433 @@ void _register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACK
 
 static inline void _ccv_nnc_cmd_init(void)
 {
-	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD(&init_map[0].registry);
-	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD(&init_map[1].registry);
-	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD(&init_map[2].registry);
-	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD(&init_map[3].registry);
-	_register_command_CCV_NNC_RELU_FORWARD(&init_map[4].registry);
-	_register_command_CCV_NNC_RELU_BACKWARD(&init_map[5].registry);
-	_register_command_CCV_NNC_NMS_FORWARD(&init_map[6].registry);
-	_register_command_CCV_NNC_NMS_BACKWARD(&init_map[7].registry);
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD(&init_map[8].registry);
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD(&init_map[9].registry);
+	_register_command_CCV_NNC_SIGMOID_FORWARD(&init_map[0].registry);
+	_register_command_CCV_NNC_SIGMOID_BACKWARD(&init_map[1].registry);
+	_register_command_CCV_NNC_MAX_POOL_FORWARD(&init_map[2].registry);
+	_register_command_CCV_NNC_MAX_POOL_BACKWARD(&init_map[3].registry);
+	_register_command_CCV_NNC_HISTOGRAM_FORWARD(&init_map[4].registry);
+	_register_command_CCV_NNC_HISTOGRAM_BACKWARD(&init_map[5].registry);
+	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD(&init_map[6].registry);
+	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD(&init_map[7].registry);
+	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD(&init_map[8].registry);
+	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD(&init_map[9].registry);
 	_register_command_CCV_NNC_DATA_TRANSFER_FORWARD(&init_map[10].registry);
 	_register_command_CCV_NNC_DATA_TRANSFER_BACKWARD(&init_map[11].registry);
-	_register_command_CCV_NNC_COMM_REDUCE_FORWARD(&init_map[12].registry);
-	_register_command_CCV_NNC_COMM_REDUCE_BACKWARD(&init_map[13].registry);
-	_register_command_CCV_NNC_SGD_FORWARD(&init_map[14].registry);
-	_register_command_CCV_NNC_SGD_BACKWARD(&init_map[15].registry);
+	_register_command_CCV_NNC_RELU_FORWARD(&init_map[12].registry);
+	_register_command_CCV_NNC_RELU_BACKWARD(&init_map[13].registry);
+	_register_command_CCV_NNC_COMM_REDUCE_FORWARD(&init_map[14].registry);
+	_register_command_CCV_NNC_COMM_REDUCE_BACKWARD(&init_map[15].registry);
 	_register_command_CCV_NNC_EWDIV_FORWARD(&init_map[16].registry);
 	_register_command_CCV_NNC_EWDIV_BACKWARD(&init_map[17].registry);
-	_register_command_CCV_NNC_MAX_POOL_FORWARD(&init_map[18].registry);
-	_register_command_CCV_NNC_MAX_POOL_BACKWARD(&init_map[19].registry);
-	_register_command_CCV_NNC_EWSUM_FORWARD(&init_map[20].registry);
-	_register_command_CCV_NNC_EWSUM_BACKWARD(&init_map[21].registry);
-	_register_command_CCV_NNC_GROUP_NORM_FORWARD(&init_map[22].registry);
-	_register_command_CCV_NNC_GROUP_NORM_BACKWARD(&init_map[23].registry);
-	_register_command_CCV_NNC_EWPROD_FORWARD(&init_map[24].registry);
-	_register_command_CCV_NNC_EWPROD_BACKWARD(&init_map[25].registry);
-	_register_command_CCV_NNC_SCALAR_MUL_FORWARD(&init_map[26].registry);
-	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD(&init_map[27].registry);
-	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD(&init_map[28].registry);
-	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD(&init_map[29].registry);
-	_register_command_CCV_NNC_REDUCE_SUM_FORWARD(&init_map[30].registry);
-	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD(&init_map[31].registry);
-	_register_command_CCV_NNC_DROPOUT_FORWARD(&init_map[32].registry);
-	_register_command_CCV_NNC_DROPOUT_BACKWARD(&init_map[33].registry);
-	_register_command_CCV_NNC_SWISH_FORWARD(&init_map[34].registry);
-	_register_command_CCV_NNC_SWISH_BACKWARD(&init_map[35].registry);
-	_register_command_CCV_NNC_EWSQRT_FORWARD(&init_map[36].registry);
-	_register_command_CCV_NNC_EWSQRT_BACKWARD(&init_map[37].registry);
-	_register_command_CCV_NNC_RMSPROP_FORWARD(&init_map[38].registry);
-	_register_command_CCV_NNC_RMSPROP_BACKWARD(&init_map[39].registry);
-	_register_command_CCV_NNC_MAX_FORWARD(&init_map[40].registry);
-	_register_command_CCV_NNC_MAX_BACKWARD(&init_map[41].registry);
-	_register_command_CCV_NNC_MUL_FORWARD(&init_map[42].registry);
-	_register_command_CCV_NNC_MUL_BACKWARD(&init_map[43].registry);
-	_register_command_CCV_NNC_SET_FORWARD(&init_map[44].registry);
-	_register_command_CCV_NNC_SET_BACKWARD(&init_map[45].registry);
-	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD(&init_map[46].registry);
-	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD(&init_map[47].registry);
-	_register_command_CCV_NNC_SMOOTH_L1_FORWARD(&init_map[48].registry);
-	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD(&init_map[49].registry);
-	_register_command_CCV_NNC_CONVOLUTION_FORWARD(&init_map[50].registry);
-	_register_command_CCV_NNC_CONVOLUTION_BACKWARD(&init_map[51].registry);
-	_register_command_CCV_NNC_MASKED_FILL_FORWARD(&init_map[52].registry);
-	_register_command_CCV_NNC_MASKED_FILL_BACKWARD(&init_map[53].registry);
-	_register_command_CCV_NNC_REDUCE_MIN_FORWARD(&init_map[54].registry);
-	_register_command_CCV_NNC_REDUCE_MIN_BACKWARD(&init_map[55].registry);
-	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD(&init_map[56].registry);
-	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD(&init_map[57].registry);
+	_register_command_CCV_NNC_DROPOUT_FORWARD(&init_map[18].registry);
+	_register_command_CCV_NNC_DROPOUT_BACKWARD(&init_map[19].registry);
+	_register_command_CCV_NNC_MSE_FORWARD(&init_map[20].registry);
+	_register_command_CCV_NNC_MSE_BACKWARD(&init_map[21].registry);
+	_register_command_CCV_NNC_MASKED_FILL_FORWARD(&init_map[22].registry);
+	_register_command_CCV_NNC_MASKED_FILL_BACKWARD(&init_map[23].registry);
+	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD(&init_map[24].registry);
+	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD(&init_map[25].registry);
+	_register_command_CCV_NNC_LAMB_FORWARD(&init_map[26].registry);
+	_register_command_CCV_NNC_LAMB_BACKWARD(&init_map[27].registry);
+	_register_command_CCV_NNC_MAX_FORWARD(&init_map[28].registry);
+	_register_command_CCV_NNC_MAX_BACKWARD(&init_map[29].registry);
+	_register_command_CCV_NNC_SMOOTH_L1_FORWARD(&init_map[30].registry);
+	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD(&init_map[31].registry);
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD(&init_map[32].registry);
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD(&init_map[33].registry);
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD(&init_map[34].registry);
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD(&init_map[35].registry);
+	_register_command_CCV_NNC_RMSPROP_FORWARD(&init_map[36].registry);
+	_register_command_CCV_NNC_RMSPROP_BACKWARD(&init_map[37].registry);
+	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD(&init_map[38].registry);
+	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD(&init_map[39].registry);
+	_register_command_CCV_NNC_EWSUM_FORWARD(&init_map[40].registry);
+	_register_command_CCV_NNC_EWSUM_BACKWARD(&init_map[41].registry);
+	_register_command_CCV_NNC_EWEXP_FORWARD(&init_map[42].registry);
+	_register_command_CCV_NNC_EWEXP_BACKWARD(&init_map[43].registry);
+	_register_command_CCV_NNC_ARGMAX_FORWARD(&init_map[44].registry);
+	_register_command_CCV_NNC_ARGMAX_BACKWARD(&init_map[45].registry);
+	_register_command_CCV_NNC_TRANSPOSE_FORWARD(&init_map[46].registry);
+	_register_command_CCV_NNC_TRANSPOSE_BACKWARD(&init_map[47].registry);
+	_register_command_CCV_NNC_REDUCE_SUM_FORWARD(&init_map[48].registry);
+	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD(&init_map[49].registry);
+	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD(&init_map[50].registry);
+	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD(&init_map[51].registry);
+	_register_command_CCV_NNC_ADD_FORWARD(&init_map[52].registry);
+	_register_command_CCV_NNC_ADD_BACKWARD(&init_map[53].registry);
+	_register_command_CCV_NNC_LAYER_NORM_FORWARD(&init_map[54].registry);
+	_register_command_CCV_NNC_LAYER_NORM_BACKWARD(&init_map[55].registry);
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD(&init_map[56].registry);
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD(&init_map[57].registry);
 	_register_command_CCV_NNC_GEMM_FORWARD(&init_map[58].registry);
 	_register_command_CCV_NNC_GEMM_BACKWARD(&init_map[59].registry);
-	_register_command_CCV_NNC_LAMB_FORWARD(&init_map[60].registry);
-	_register_command_CCV_NNC_LAMB_BACKWARD(&init_map[61].registry);
-	_register_command_CCV_NNC_SIGMOID_FORWARD(&init_map[62].registry);
-	_register_command_CCV_NNC_SIGMOID_BACKWARD(&init_map[63].registry);
-	_register_command_CCV_NNC_ROI_ALIGN_FORWARD(&init_map[64].registry);
-	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD(&init_map[65].registry);
-	_register_command_CCV_NNC_LAYER_NORM_FORWARD(&init_map[66].registry);
-	_register_command_CCV_NNC_LAYER_NORM_BACKWARD(&init_map[67].registry);
-	_register_command_CCV_NNC_UPSAMPLE_FORWARD(&init_map[68].registry);
-	_register_command_CCV_NNC_UPSAMPLE_BACKWARD(&init_map[69].registry);
-	_register_command_CCV_NNC_SOFTMAX_FORWARD(&init_map[70].registry);
-	_register_command_CCV_NNC_SOFTMAX_BACKWARD(&init_map[71].registry);
-	_register_command_CCV_NNC_MIN_FORWARD(&init_map[72].registry);
-	_register_command_CCV_NNC_MIN_BACKWARD(&init_map[73].registry);
-	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD(&init_map[74].registry);
-	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD(&init_map[75].registry);
-	_register_command_CCV_NNC_TRANSPOSE_FORWARD(&init_map[76].registry);
-	_register_command_CCV_NNC_TRANSPOSE_BACKWARD(&init_map[77].registry);
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD(&init_map[78].registry);
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD(&init_map[79].registry);
-	_register_command_CCV_NNC_REDUCE_MAX_FORWARD(&init_map[80].registry);
-	_register_command_CCV_NNC_REDUCE_MAX_BACKWARD(&init_map[81].registry);
-	_register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD(&init_map[82].registry);
-	_register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD(&init_map[83].registry);
-	_register_command_CCV_NNC_HISTOGRAM_FORWARD(&init_map[84].registry);
-	_register_command_CCV_NNC_HISTOGRAM_BACKWARD(&init_map[85].registry);
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD(&init_map[86].registry);
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD(&init_map[87].registry);
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD(&init_map[88].registry);
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD(&init_map[89].registry);
-	_register_command_CCV_NNC_GELU_FORWARD(&init_map[90].registry);
-	_register_command_CCV_NNC_GELU_BACKWARD(&init_map[91].registry);
-	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD(&init_map[92].registry);
-	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD(&init_map[93].registry);
-	_register_command_CCV_NNC_ARGMAX_FORWARD(&init_map[94].registry);
-	_register_command_CCV_NNC_ARGMAX_BACKWARD(&init_map[95].registry);
-	_register_command_CCV_NNC_ADAMW_FORWARD(&init_map[96].registry);
-	_register_command_CCV_NNC_ADAMW_BACKWARD(&init_map[97].registry);
-	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD(&init_map[98].registry);
-	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD(&init_map[99].registry);
-	_register_command_CCV_NNC_ARGMIN_FORWARD(&init_map[100].registry);
-	_register_command_CCV_NNC_ARGMIN_BACKWARD(&init_map[101].registry);
-	_register_command_CCV_NNC_ADAM_FORWARD(&init_map[102].registry);
-	_register_command_CCV_NNC_ADAM_BACKWARD(&init_map[103].registry);
-	_register_command_CCV_NNC_EWEXP_FORWARD(&init_map[104].registry);
-	_register_command_CCV_NNC_EWEXP_BACKWARD(&init_map[105].registry);
-	_register_command_CCV_NNC_LEAKY_RELU_FORWARD(&init_map[106].registry);
-	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD(&init_map[107].registry);
-	_register_command_CCV_NNC_EWLOG_FORWARD(&init_map[108].registry);
-	_register_command_CCV_NNC_EWLOG_BACKWARD(&init_map[109].registry);
-	_register_command_CCV_NNC_TANH_FORWARD(&init_map[110].registry);
-	_register_command_CCV_NNC_TANH_BACKWARD(&init_map[111].registry);
-	_register_command_CCV_NNC_COMM_BROADCAST_FORWARD(&init_map[112].registry);
-	_register_command_CCV_NNC_COMM_BROADCAST_BACKWARD(&init_map[113].registry);
-	_register_command_CCV_NNC_MSE_FORWARD(&init_map[114].registry);
-	_register_command_CCV_NNC_MSE_BACKWARD(&init_map[115].registry);
-	_register_command_CCV_NNC_BATCH_NORM_FORWARD(&init_map[116].registry);
-	_register_command_CCV_NNC_BATCH_NORM_BACKWARD(&init_map[117].registry);
-	_register_command_CCV_NNC_ADD_FORWARD(&init_map[118].registry);
-	_register_command_CCV_NNC_ADD_BACKWARD(&init_map[119].registry);
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD(&init_map[120].registry);
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD(&init_map[121].registry);
-	_register_command_CCV_NNC_LSTM_FORWARD(&init_map[122].registry);
-	_register_command_CCV_NNC_LSTM_BACKWARD(&init_map[123].registry);
-	_register_command_CCV_NNC_CLAMP_FORWARD(&init_map[124].registry);
-	_register_command_CCV_NNC_CLAMP_BACKWARD(&init_map[125].registry);
-	_register_command_CCV_NNC_INDEX_SELECT_FORWARD(&init_map[126].registry);
-	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD(&init_map[127].registry);
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD(&init_map[128].registry);
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD(&init_map[129].registry);
+	_register_command_CCV_NNC_COMM_BROADCAST_FORWARD(&init_map[60].registry);
+	_register_command_CCV_NNC_COMM_BROADCAST_BACKWARD(&init_map[61].registry);
+	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD(&init_map[62].registry);
+	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD(&init_map[63].registry);
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD(&init_map[64].registry);
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD(&init_map[65].registry);
+	_register_command_CCV_NNC_MIN_FORWARD(&init_map[66].registry);
+	_register_command_CCV_NNC_MIN_BACKWARD(&init_map[67].registry);
+	_register_command_CCV_NNC_MUL_FORWARD(&init_map[68].registry);
+	_register_command_CCV_NNC_MUL_BACKWARD(&init_map[69].registry);
+	_register_command_CCV_NNC_GROUP_NORM_FORWARD(&init_map[70].registry);
+	_register_command_CCV_NNC_GROUP_NORM_BACKWARD(&init_map[71].registry);
+	_register_command_CCV_NNC_SET_FORWARD(&init_map[72].registry);
+	_register_command_CCV_NNC_SET_BACKWARD(&init_map[73].registry);
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD(&init_map[74].registry);
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD(&init_map[75].registry);
+	_register_command_CCV_NNC_INDEX_SELECT_FORWARD(&init_map[76].registry);
+	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD(&init_map[77].registry);
+	_register_command_CCV_NNC_ARGMIN_FORWARD(&init_map[78].registry);
+	_register_command_CCV_NNC_ARGMIN_BACKWARD(&init_map[79].registry);
+	_register_command_CCV_NNC_GELU_FORWARD(&init_map[80].registry);
+	_register_command_CCV_NNC_GELU_BACKWARD(&init_map[81].registry);
+	_register_command_CCV_NNC_ADAMW_FORWARD(&init_map[82].registry);
+	_register_command_CCV_NNC_ADAMW_BACKWARD(&init_map[83].registry);
+	_register_command_CCV_NNC_NMS_FORWARD(&init_map[84].registry);
+	_register_command_CCV_NNC_NMS_BACKWARD(&init_map[85].registry);
+	_register_command_CCV_NNC_UPSAMPLE_FORWARD(&init_map[86].registry);
+	_register_command_CCV_NNC_UPSAMPLE_BACKWARD(&init_map[87].registry);
+	_register_command_CCV_NNC_LSTM_FORWARD(&init_map[88].registry);
+	_register_command_CCV_NNC_LSTM_BACKWARD(&init_map[89].registry);
+	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD(&init_map[90].registry);
+	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD(&init_map[91].registry);
+	_register_command_CCV_NNC_TANH_FORWARD(&init_map[92].registry);
+	_register_command_CCV_NNC_TANH_BACKWARD(&init_map[93].registry);
+	_register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD(&init_map[94].registry);
+	_register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD(&init_map[95].registry);
+	_register_command_CCV_NNC_EWPROD_FORWARD(&init_map[96].registry);
+	_register_command_CCV_NNC_EWPROD_BACKWARD(&init_map[97].registry);
+	_register_command_CCV_NNC_CLAMP_FORWARD(&init_map[98].registry);
+	_register_command_CCV_NNC_CLAMP_BACKWARD(&init_map[99].registry);
+	_register_command_CCV_NNC_ADAM_FORWARD(&init_map[100].registry);
+	_register_command_CCV_NNC_ADAM_BACKWARD(&init_map[101].registry);
+	_register_command_CCV_NNC_BATCH_NORM_FORWARD(&init_map[102].registry);
+	_register_command_CCV_NNC_BATCH_NORM_BACKWARD(&init_map[103].registry);
+	_register_command_CCV_NNC_CONVOLUTION_FORWARD(&init_map[104].registry);
+	_register_command_CCV_NNC_CONVOLUTION_BACKWARD(&init_map[105].registry);
+	_register_command_CCV_NNC_REDUCE_MAX_FORWARD(&init_map[106].registry);
+	_register_command_CCV_NNC_REDUCE_MAX_BACKWARD(&init_map[107].registry);
+	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD(&init_map[108].registry);
+	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD(&init_map[109].registry);
+	_register_command_CCV_NNC_ROI_ALIGN_FORWARD(&init_map[110].registry);
+	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD(&init_map[111].registry);
+	_register_command_CCV_NNC_REDUCE_MIN_FORWARD(&init_map[112].registry);
+	_register_command_CCV_NNC_REDUCE_MIN_BACKWARD(&init_map[113].registry);
+	_register_command_CCV_NNC_SOFTMAX_FORWARD(&init_map[114].registry);
+	_register_command_CCV_NNC_SOFTMAX_BACKWARD(&init_map[115].registry);
+	_register_command_CCV_NNC_EWLOG_FORWARD(&init_map[116].registry);
+	_register_command_CCV_NNC_EWLOG_BACKWARD(&init_map[117].registry);
+	_register_command_CCV_NNC_LEAKY_RELU_FORWARD(&init_map[118].registry);
+	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD(&init_map[119].registry);
+	_register_command_CCV_NNC_EWSQRT_FORWARD(&init_map[120].registry);
+	_register_command_CCV_NNC_EWSQRT_BACKWARD(&init_map[121].registry);
+	_register_command_CCV_NNC_SWISH_FORWARD(&init_map[122].registry);
+	_register_command_CCV_NNC_SWISH_BACKWARD(&init_map[123].registry);
+	_register_command_CCV_NNC_SCALAR_MUL_FORWARD(&init_map[124].registry);
+	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD(&init_map[125].registry);
+	_register_command_CCV_NNC_SGD_FORWARD(&init_map[126].registry);
+	_register_command_CCV_NNC_SGD_BACKWARD(&init_map[127].registry);
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD(&init_map[128].registry);
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD(&init_map[129].registry);
 
-	_register_command_CCV_NNC_ADAM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[102].backends[2]));
-	_register_command_CCV_NNC_ADAM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[103].backends[2]));
-	_register_command_CCV_NNC_ADAMW_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[96].backends[2]));
-	_register_command_CCV_NNC_ADAMW_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[97].backends[2]));
+	_register_command_CCV_NNC_ADAM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[100].backends[2]));
+	_register_command_CCV_NNC_ADAM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[101].backends[2]));
+	_register_command_CCV_NNC_ADAMW_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[82].backends[2]));
+	_register_command_CCV_NNC_ADAMW_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[83].backends[2]));
 	_register_command_CCV_NNC_GEMM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[58].backends[2]));
 	_register_command_CCV_NNC_GEMM_FORWARD_backend_CCV_NNC_BACKEND_CPU_OPT(&(init_map[58].backends[4]));
 	_register_command_CCV_NNC_GEMM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[59].backends[2]));
 	_register_command_CCV_NNC_GEMM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_OPT(&(init_map[59].backends[4]));
-	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[118].backends[2]));
-	_register_command_CCV_NNC_ADD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[119].backends[2]));
-	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[42].backends[2]));
-	_register_command_CCV_NNC_MUL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[43].backends[2]));
-	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[26].backends[2]));
-	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[27].backends[2]));
-	_register_command_CCV_NNC_MIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[72].backends[2]));
-	_register_command_CCV_NNC_MIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[73].backends[2]));
-	_register_command_CCV_NNC_MAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[40].backends[2]));
-	_register_command_CCV_NNC_MAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[41].backends[2]));
-	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[56].backends[2]));
-	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[57].backends[2]));
-	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[50].backends[2]));
-	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_OPT(&(init_map[50].backends[4]));
-	_register_command_CCV_NNC_CONVOLUTION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[51].backends[2]));
-	_register_command_CCV_NNC_DROPOUT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[32].backends[2]));
-	_register_command_CCV_NNC_DROPOUT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[33].backends[2]));
-	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[20].backends[2]));
-	_register_command_CCV_NNC_EWSUM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[21].backends[2]));
-	_register_command_CCV_NNC_EWPROD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[24].backends[2]));
-	_register_command_CCV_NNC_EWPROD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[25].backends[2]));
+	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[52].backends[2]));
+	_register_command_CCV_NNC_ADD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[53].backends[2]));
+	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[68].backends[2]));
+	_register_command_CCV_NNC_MUL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[69].backends[2]));
+	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[124].backends[2]));
+	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[125].backends[2]));
+	_register_command_CCV_NNC_MIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[66].backends[2]));
+	_register_command_CCV_NNC_MIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[67].backends[2]));
+	_register_command_CCV_NNC_MAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[28].backends[2]));
+	_register_command_CCV_NNC_MAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[29].backends[2]));
+	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[62].backends[2]));
+	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[63].backends[2]));
+	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[104].backends[2]));
+	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_OPT(&(init_map[104].backends[4]));
+	_register_command_CCV_NNC_CONVOLUTION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[105].backends[2]));
+	_register_command_CCV_NNC_DROPOUT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[18].backends[2]));
+	_register_command_CCV_NNC_DROPOUT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[19].backends[2]));
+	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[40].backends[2]));
+	_register_command_CCV_NNC_EWSUM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[41].backends[2]));
+	_register_command_CCV_NNC_EWPROD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[96].backends[2]));
+	_register_command_CCV_NNC_EWPROD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[97].backends[2]));
 	_register_command_CCV_NNC_EWDIV_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[16].backends[2]));
 	_register_command_CCV_NNC_EWDIV_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[17].backends[2]));
-	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[104].backends[2]));
-	_register_command_CCV_NNC_EWEXP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[105].backends[2]));
-	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[108].backends[2]));
-	_register_command_CCV_NNC_EWLOG_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[109].backends[2]));
-	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[36].backends[2]));
-	_register_command_CCV_NNC_EWSQRT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[37].backends[2]));
-	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[124].backends[2]));
-	_register_command_CCV_NNC_CLAMP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[125].backends[2]));
-	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[90].backends[2]));
-	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[91].backends[2]));
-	_register_command_CCV_NNC_HISTOGRAM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[84].backends[2]));
-	_register_command_CCV_NNC_HISTOGRAM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[85].backends[2]));
-	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[126].backends[2]));
-	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[127].backends[2]));
-	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[74].backends[2]));
-	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[75].backends[2]));
-	_register_command_CCV_NNC_LAMB_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[60].backends[2]));
-	_register_command_CCV_NNC_LAMB_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[61].backends[2]));
-	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[106].backends[2]));
-	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[107].backends[2]));
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[78].backends[2]));
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[79].backends[2]));
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[120].backends[2]));
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[121].backends[2]));
-	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[114].backends[2]));
-	_register_command_CCV_NNC_MSE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[115].backends[2]));
-	_register_command_CCV_NNC_SMOOTH_L1_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[48].backends[2]));
-	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[49].backends[2]));
-	_register_command_CCV_NNC_NMS_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[6].backends[2]));
-	_register_command_CCV_NNC_NMS_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[7].backends[2]));
-	_register_command_CCV_NNC_BATCH_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[116].backends[2]));
-	_register_command_CCV_NNC_BATCH_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[117].backends[2]));
-	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[66].backends[2]));
-	_register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[67].backends[2]));
-	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[22].backends[2]));
-	_register_command_CCV_NNC_GROUP_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[23].backends[2]));
-	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[18].backends[2]));
-	_register_command_CCV_NNC_MAX_POOL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[19].backends[2]));
-	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[46].backends[2]));
-	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[47].backends[2]));
-	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[92].backends[2]));
-	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[93].backends[2]));
-	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[28].backends[2]));
-	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[29].backends[2]));
-	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[30].backends[2]));
-	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[31].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[98].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[99].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[80].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[81].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[54].backends[2]));
-	_register_command_CCV_NNC_REDUCE_MIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[55].backends[2]));
-	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[0].backends[2]));
-	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[1].backends[2]));
-	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[94].backends[2]));
-	_register_command_CCV_NNC_ARGMAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[95].backends[2]));
-	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[100].backends[2]));
-	_register_command_CCV_NNC_ARGMIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[101].backends[2]));
-	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[4].backends[2]));
-	_register_command_CCV_NNC_RELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[5].backends[2]));
-	_register_command_CCV_NNC_RMSPROP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[38].backends[2]));
-	_register_command_CCV_NNC_RMSPROP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[39].backends[2]));
-	_register_command_CCV_NNC_ROI_ALIGN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[64].backends[2]));
-	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[65].backends[2]));
-	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[2].backends[2]));
-	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[3].backends[2]));
-	_register_command_CCV_NNC_SGD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[14].backends[2]));
-	_register_command_CCV_NNC_SGD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[15].backends[2]));
-	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[62].backends[2]));
-	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[63].backends[2]));
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[86].backends[2]));
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[87].backends[2]));
-	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[70].backends[2]));
-	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[71].backends[2]));
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[88].backends[2]));
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[89].backends[2]));
-	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[34].backends[2]));
-	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[35].backends[2]));
-	_register_command_CCV_NNC_TANH_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[110].backends[2]));
-	_register_command_CCV_NNC_TANH_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[111].backends[2]));
-	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[68].backends[2]));
-	_register_command_CCV_NNC_UPSAMPLE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[69].backends[2]));
-	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[44].backends[2]));
-	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[45].backends[2]));
-	_register_command_CCV_NNC_MASKED_FILL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[52].backends[2]));
-	_register_command_CCV_NNC_MASKED_FILL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[53].backends[2]));
+	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[42].backends[2]));
+	_register_command_CCV_NNC_EWEXP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[43].backends[2]));
+	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[116].backends[2]));
+	_register_command_CCV_NNC_EWLOG_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[117].backends[2]));
+	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[120].backends[2]));
+	_register_command_CCV_NNC_EWSQRT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[121].backends[2]));
+	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[98].backends[2]));
+	_register_command_CCV_NNC_CLAMP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[99].backends[2]));
+	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[80].backends[2]));
+	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[81].backends[2]));
+	_register_command_CCV_NNC_HISTOGRAM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[4].backends[2]));
+	_register_command_CCV_NNC_HISTOGRAM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[5].backends[2]));
+	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[76].backends[2]));
+	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[77].backends[2]));
+	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[6].backends[2]));
+	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[7].backends[2]));
+	_register_command_CCV_NNC_LAMB_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[26].backends[2]));
+	_register_command_CCV_NNC_LAMB_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[27].backends[2]));
+	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[118].backends[2]));
+	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[119].backends[2]));
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[32].backends[2]));
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[33].backends[2]));
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[34].backends[2]));
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[35].backends[2]));
+	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[20].backends[2]));
+	_register_command_CCV_NNC_MSE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[21].backends[2]));
+	_register_command_CCV_NNC_SMOOTH_L1_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[30].backends[2]));
+	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[31].backends[2]));
+	_register_command_CCV_NNC_NMS_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[84].backends[2]));
+	_register_command_CCV_NNC_NMS_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[85].backends[2]));
+	_register_command_CCV_NNC_BATCH_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[102].backends[2]));
+	_register_command_CCV_NNC_BATCH_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[103].backends[2]));
+	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[54].backends[2]));
+	_register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[55].backends[2]));
+	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[70].backends[2]));
+	_register_command_CCV_NNC_GROUP_NORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[71].backends[2]));
+	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[2].backends[2]));
+	_register_command_CCV_NNC_MAX_POOL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[3].backends[2]));
+	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[90].backends[2]));
+	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[91].backends[2]));
+	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[8].backends[2]));
+	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[9].backends[2]));
+	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[50].backends[2]));
+	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[51].backends[2]));
+	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[48].backends[2]));
+	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[49].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[24].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[25].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[106].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[107].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[112].backends[2]));
+	_register_command_CCV_NNC_REDUCE_MIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[113].backends[2]));
+	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[108].backends[2]));
+	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[109].backends[2]));
+	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[44].backends[2]));
+	_register_command_CCV_NNC_ARGMAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[45].backends[2]));
+	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[78].backends[2]));
+	_register_command_CCV_NNC_ARGMIN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[79].backends[2]));
+	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[12].backends[2]));
+	_register_command_CCV_NNC_RELU_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[13].backends[2]));
+	_register_command_CCV_NNC_RMSPROP_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[36].backends[2]));
+	_register_command_CCV_NNC_RMSPROP_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[37].backends[2]));
+	_register_command_CCV_NNC_ROI_ALIGN_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[110].backends[2]));
+	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[111].backends[2]));
+	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[38].backends[2]));
+	_register_command_CCV_NNC_SCALED_DOT_PRODUCT_ATTENTION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[39].backends[2]));
+	_register_command_CCV_NNC_SGD_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[126].backends[2]));
+	_register_command_CCV_NNC_SGD_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[127].backends[2]));
+	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[0].backends[2]));
+	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[1].backends[2]));
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[128].backends[2]));
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[129].backends[2]));
+	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[114].backends[2]));
+	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[115].backends[2]));
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[64].backends[2]));
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[65].backends[2]));
+	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[122].backends[2]));
+	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[123].backends[2]));
+	_register_command_CCV_NNC_TANH_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[92].backends[2]));
+	_register_command_CCV_NNC_TANH_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[93].backends[2]));
+	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[86].backends[2]));
+	_register_command_CCV_NNC_UPSAMPLE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[87].backends[2]));
+	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[72].backends[2]));
+	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[73].backends[2]));
+	_register_command_CCV_NNC_MASKED_FILL_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[22].backends[2]));
+	_register_command_CCV_NNC_MASKED_FILL_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[23].backends[2]));
 	_register_command_CCV_NNC_DATA_TRANSFER_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[10].backends[2]));
 	_register_command_CCV_NNC_DATA_TRANSFER_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[11].backends[2]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[8].backends[2]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[9].backends[2]));
-	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[76].backends[2]));
-	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[77].backends[2]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[128].backends[2]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[129].backends[2]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[56].backends[2]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[57].backends[2]));
+	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[46].backends[2]));
+	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[47].backends[2]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[74].backends[2]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_CPU_REF(&(init_map[75].backends[2]));
 #ifdef HAVE_CUDA
-	_register_command_CCV_NNC_ADAM_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[102].backends[5]));
-	_register_command_CCV_NNC_ADAM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[103].backends[5]));
-	_register_command_CCV_NNC_ADAMW_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[96].backends[5]));
-	_register_command_CCV_NNC_ADAMW_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[97].backends[5]));
+	_register_command_CCV_NNC_ADAM_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[100].backends[5]));
+	_register_command_CCV_NNC_ADAM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[101].backends[5]));
+	_register_command_CCV_NNC_ADAMW_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[82].backends[5]));
+	_register_command_CCV_NNC_ADAMW_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[83].backends[5]));
 	_register_command_CCV_NNC_GEMM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUBLAS(&(init_map[58].backends[0]));
 	_register_command_CCV_NNC_GEMM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUBLAS(&(init_map[59].backends[0]));
-	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[118].backends[3]));
-	_register_command_CCV_NNC_ADD_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[119].backends[3]));
-	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[42].backends[3]));
-	_register_command_CCV_NNC_MUL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[43].backends[3]));
-	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[26].backends[3]));
-	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[27].backends[3]));
-	_register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[82].backends[1]));
-	_register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[83].backends[1]));
-	_register_command_CCV_NNC_COMM_BROADCAST_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[112].backends[1]));
-	_register_command_CCV_NNC_COMM_BROADCAST_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[113].backends[1]));
-	_register_command_CCV_NNC_COMM_REDUCE_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[12].backends[1]));
-	_register_command_CCV_NNC_COMM_REDUCE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[13].backends[1]));
-	_register_command_CCV_NNC_MIN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[72].backends[5]));
-	_register_command_CCV_NNC_MIN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[73].backends[5]));
-	_register_command_CCV_NNC_MAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[40].backends[5]));
-	_register_command_CCV_NNC_MAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[41].backends[5]));
-	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[56].backends[5]));
-	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[57].backends[5]));
-	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[50].backends[3]));
-	_register_command_CCV_NNC_CONVOLUTION_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[51].backends[3]));
-	_register_command_CCV_NNC_DROPOUT_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[32].backends[3]));
-	_register_command_CCV_NNC_DROPOUT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[33].backends[3]));
-	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[20].backends[3]));
-	_register_command_CCV_NNC_EWSUM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[21].backends[3]));
+	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[52].backends[3]));
+	_register_command_CCV_NNC_ADD_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[53].backends[3]));
+	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[68].backends[3]));
+	_register_command_CCV_NNC_MUL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[69].backends[3]));
+	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[124].backends[3]));
+	_register_command_CCV_NNC_SCALAR_MUL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[125].backends[3]));
+	_register_command_CCV_NNC_COMM_ALLREDUCE_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[94].backends[1]));
+	_register_command_CCV_NNC_COMM_ALLREDUCE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[95].backends[1]));
+	_register_command_CCV_NNC_COMM_BROADCAST_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[60].backends[1]));
+	_register_command_CCV_NNC_COMM_BROADCAST_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[61].backends[1]));
+	_register_command_CCV_NNC_COMM_REDUCE_FORWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[14].backends[1]));
+	_register_command_CCV_NNC_COMM_REDUCE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_NCCL(&(init_map[15].backends[1]));
+	_register_command_CCV_NNC_MIN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[66].backends[5]));
+	_register_command_CCV_NNC_MIN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[67].backends[5]));
+	_register_command_CCV_NNC_MAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[28].backends[5]));
+	_register_command_CCV_NNC_MAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[29].backends[5]));
+	_register_command_CCV_NNC_COMPRESSION_LSSC_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[62].backends[5]));
+	_register_command_CCV_NNC_COMPRESSION_LSSC_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[63].backends[5]));
+	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[104].backends[3]));
+	_register_command_CCV_NNC_CONVOLUTION_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[105].backends[3]));
+	_register_command_CCV_NNC_DROPOUT_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[18].backends[3]));
+	_register_command_CCV_NNC_DROPOUT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[19].backends[3]));
+	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[40].backends[3]));
+	_register_command_CCV_NNC_EWSUM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[41].backends[3]));
 	_register_command_CCV_NNC_EWDIV_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[16].backends[5]));
 	_register_command_CCV_NNC_EWDIV_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[17].backends[5]));
-	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[104].backends[5]));
-	_register_command_CCV_NNC_EWEXP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[105].backends[5]));
-	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[108].backends[5]));
-	_register_command_CCV_NNC_EWLOG_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[109].backends[5]));
-	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[36].backends[5]));
-	_register_command_CCV_NNC_EWSQRT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[37].backends[5]));
-	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[124].backends[5]));
-	_register_command_CCV_NNC_CLAMP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[125].backends[5]));
-	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[90].backends[5]));
-	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[91].backends[5]));
-	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[126].backends[5]));
-	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[127].backends[5]));
-	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[74].backends[3]));
-	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[75].backends[3]));
-	_register_command_CCV_NNC_LAMB_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[60].backends[5]));
-	_register_command_CCV_NNC_LAMB_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[61].backends[5]));
-	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[106].backends[5]));
-	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[107].backends[5]));
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[78].backends[5]));
-	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[79].backends[5]));
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[120].backends[5]));
-	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[121].backends[5]));
-	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[114].backends[5]));
-	_register_command_CCV_NNC_MSE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[115].backends[5]));
-	_register_command_CCV_NNC_SMOOTH_L1_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[48].backends[5]));
-	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[49].backends[5]));
-	_register_command_CCV_NNC_NMS_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[6].backends[5]));
-	_register_command_CCV_NNC_NMS_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[7].backends[5]));
-	_register_command_CCV_NNC_BATCH_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[116].backends[3]));
-	_register_command_CCV_NNC_BATCH_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[117].backends[3]));
-	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[66].backends[3]));
-	_register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[67].backends[3]));
-	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[22].backends[3]));
-	_register_command_CCV_NNC_GROUP_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[23].backends[3]));
-	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[18].backends[3]));
-	_register_command_CCV_NNC_MAX_POOL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[19].backends[3]));
-	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[46].backends[3]));
-	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[47].backends[3]));
-	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[92].backends[5]));
-	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[93].backends[5]));
-	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[28].backends[5]));
-	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[29].backends[5]));
-	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[30].backends[3]));
-	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[31].backends[3]));
-	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[98].backends[3]));
-	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[99].backends[3]));
-	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[0].backends[3]));
-	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[1].backends[3]));
-	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[94].backends[5]));
-	_register_command_CCV_NNC_ARGMAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[95].backends[5]));
-	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[100].backends[5]));
-	_register_command_CCV_NNC_ARGMIN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[101].backends[5]));
-	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[4].backends[3]));
-	_register_command_CCV_NNC_RELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[5].backends[3]));
-	_register_command_CCV_NNC_RMSPROP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[38].backends[5]));
-	_register_command_CCV_NNC_RMSPROP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[39].backends[5]));
-	_register_command_CCV_NNC_LSTM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[122].backends[3]));
-	_register_command_CCV_NNC_LSTM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[123].backends[3]));
-	_register_command_CCV_NNC_ROI_ALIGN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[64].backends[5]));
-	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[65].backends[5]));
-	_register_command_CCV_NNC_SGD_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[14].backends[5]));
-	_register_command_CCV_NNC_SGD_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[15].backends[5]));
-	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[62].backends[3]));
-	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[63].backends[3]));
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[86].backends[5]));
-	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[87].backends[5]));
-	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[70].backends[3]));
-	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[71].backends[3]));
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[88].backends[3]));
-	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[89].backends[3]));
-	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[34].backends[5]));
-	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[35].backends[5]));
-	_register_command_CCV_NNC_TANH_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[110].backends[3]));
-	_register_command_CCV_NNC_TANH_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[111].backends[3]));
-	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[68].backends[5]));
-	_register_command_CCV_NNC_UPSAMPLE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[69].backends[5]));
-	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[44].backends[3]));
-	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[45].backends[3]));
-	_register_command_CCV_NNC_MASKED_FILL_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[52].backends[5]));
-	_register_command_CCV_NNC_MASKED_FILL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[53].backends[5]));
+	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[42].backends[5]));
+	_register_command_CCV_NNC_EWEXP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[43].backends[5]));
+	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[116].backends[5]));
+	_register_command_CCV_NNC_EWLOG_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[117].backends[5]));
+	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[120].backends[5]));
+	_register_command_CCV_NNC_EWSQRT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[121].backends[5]));
+	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[98].backends[5]));
+	_register_command_CCV_NNC_CLAMP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[99].backends[5]));
+	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[80].backends[5]));
+	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[81].backends[5]));
+	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[76].backends[5]));
+	_register_command_CCV_NNC_INDEX_SELECT_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[77].backends[5]));
+	_register_command_CCV_NNC_REDUCE_ISNAN_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[6].backends[3]));
+	_register_command_CCV_NNC_REDUCE_ISNAN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[7].backends[3]));
+	_register_command_CCV_NNC_LAMB_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[26].backends[5]));
+	_register_command_CCV_NNC_LAMB_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[27].backends[5]));
+	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[118].backends[5]));
+	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[119].backends[5]));
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[32].backends[5]));
+	_register_command_CCV_NNC_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[33].backends[5]));
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[34].backends[5]));
+	_register_command_CCV_NNC_CATEGORICAL_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[35].backends[5]));
+	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[20].backends[5]));
+	_register_command_CCV_NNC_MSE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[21].backends[5]));
+	_register_command_CCV_NNC_SMOOTH_L1_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[30].backends[5]));
+	_register_command_CCV_NNC_SMOOTH_L1_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[31].backends[5]));
+	_register_command_CCV_NNC_NMS_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[84].backends[5]));
+	_register_command_CCV_NNC_NMS_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[85].backends[5]));
+	_register_command_CCV_NNC_BATCH_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[102].backends[3]));
+	_register_command_CCV_NNC_BATCH_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[103].backends[3]));
+	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[54].backends[3]));
+	_register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[55].backends[3]));
+	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[70].backends[3]));
+	_register_command_CCV_NNC_GROUP_NORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[71].backends[3]));
+	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[2].backends[3]));
+	_register_command_CCV_NNC_MAX_POOL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[3].backends[3]));
+	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[90].backends[3]));
+	_register_command_CCV_NNC_AVERAGE_POOL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[91].backends[3]));
+	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[8].backends[5]));
+	_register_command_CCV_NNC_RANDOM_UNIFORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[9].backends[5]));
+	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[50].backends[5]));
+	_register_command_CCV_NNC_RANDOM_NORMAL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[51].backends[5]));
+	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[48].backends[3]));
+	_register_command_CCV_NNC_REDUCE_SUM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[49].backends[3]));
+	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[24].backends[3]));
+	_register_command_CCV_NNC_REDUCE_MEAN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[25].backends[3]));
+	_register_command_CCV_NNC_REDUCE_NORM2_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[108].backends[3]));
+	_register_command_CCV_NNC_REDUCE_NORM2_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[109].backends[3]));
+	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[44].backends[5]));
+	_register_command_CCV_NNC_ARGMAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[45].backends[5]));
+	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[78].backends[5]));
+	_register_command_CCV_NNC_ARGMIN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[79].backends[5]));
+	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[12].backends[3]));
+	_register_command_CCV_NNC_RELU_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[13].backends[3]));
+	_register_command_CCV_NNC_RMSPROP_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[36].backends[5]));
+	_register_command_CCV_NNC_RMSPROP_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[37].backends[5]));
+	_register_command_CCV_NNC_LSTM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[88].backends[3]));
+	_register_command_CCV_NNC_LSTM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[89].backends[3]));
+	_register_command_CCV_NNC_ROI_ALIGN_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[110].backends[5]));
+	_register_command_CCV_NNC_ROI_ALIGN_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[111].backends[5]));
+	_register_command_CCV_NNC_SGD_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[126].backends[5]));
+	_register_command_CCV_NNC_SGD_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[127].backends[5]));
+	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[0].backends[3]));
+	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[1].backends[3]));
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[128].backends[5]));
+	_register_command_CCV_NNC_SIGMOID_BINARY_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[129].backends[5]));
+	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[114].backends[3]));
+	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[115].backends[3]));
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[64].backends[3]));
+	_register_command_CCV_NNC_SOFTMAX_CROSSENTROPY_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[65].backends[3]));
+	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[122].backends[5]));
+	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[123].backends[5]));
+	_register_command_CCV_NNC_TANH_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[92].backends[3]));
+	_register_command_CCV_NNC_TANH_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[93].backends[3]));
+	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[86].backends[5]));
+	_register_command_CCV_NNC_UPSAMPLE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[87].backends[5]));
+	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[72].backends[3]));
+	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[73].backends[3]));
+	_register_command_CCV_NNC_MASKED_FILL_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[22].backends[5]));
+	_register_command_CCV_NNC_MASKED_FILL_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[23].backends[5]));
 	_register_command_CCV_NNC_DATA_TRANSFER_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[10].backends[5]));
 	_register_command_CCV_NNC_DATA_TRANSFER_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[11].backends[5]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[8].backends[3]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[9].backends[3]));
-	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[76].backends[3]));
-	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[77].backends[3]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[128].backends[5]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[129].backends[5]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[56].backends[3]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[57].backends[3]));
+	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[46].backends[3]));
+	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_GPU_CUDNN(&(init_map[47].backends[3]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[74].backends[5]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_GPU_REF(&(init_map[75].backends[5]));
 #endif
 #ifdef HAVE_MPS
 	_register_command_CCV_NNC_GEMM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[58].backends[6]));
 	_register_command_CCV_NNC_GEMM_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[59].backends[6]));
-	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[118].backends[6]));
-	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[42].backends[6]));
-	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[26].backends[6]));
-	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[50].backends[6]));
-	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[20].backends[6]));
+	_register_command_CCV_NNC_ADD_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[52].backends[6]));
+	_register_command_CCV_NNC_MUL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[68].backends[6]));
+	_register_command_CCV_NNC_SCALAR_MUL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[124].backends[6]));
+	_register_command_CCV_NNC_CONVOLUTION_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[104].backends[6]));
+	_register_command_CCV_NNC_EWSUM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[40].backends[6]));
 	_register_command_CCV_NNC_EWDIV_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[16].backends[6]));
-	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[104].backends[6]));
-	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[108].backends[6]));
-	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[36].backends[6]));
-	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[124].backends[6]));
-	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[90].backends[6]));
-	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[91].backends[6]));
-	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[126].backends[6]));
-	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[106].backends[6]));
-	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[107].backends[6]));
-	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[114].backends[6]));
-	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[66].backends[6]));
-	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[22].backends[6]));
-	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[18].backends[6]));
-	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[46].backends[6]));
-	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[92].backends[6]));
-	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[28].backends[6]));
-	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[30].backends[6]));
-	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[98].backends[6]));
-	_register_command_CCV_NNC_REDUCE_MAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[80].backends[6]));
-	_register_command_CCV_NNC_REDUCE_MIN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[54].backends[6]));
-	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[94].backends[6]));
-	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[100].backends[6]));
-	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[4].backends[6]));
-	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[62].backends[6]));
-	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[63].backends[6]));
-	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[70].backends[6]));
-	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[71].backends[6]));
-	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[34].backends[6]));
-	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[35].backends[6]));
-	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[68].backends[6]));
-	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[44].backends[6]));
-	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[45].backends[6]));
+	_register_command_CCV_NNC_EWEXP_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[42].backends[6]));
+	_register_command_CCV_NNC_EWLOG_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[116].backends[6]));
+	_register_command_CCV_NNC_EWSQRT_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[120].backends[6]));
+	_register_command_CCV_NNC_CLAMP_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[98].backends[6]));
+	_register_command_CCV_NNC_GELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[80].backends[6]));
+	_register_command_CCV_NNC_GELU_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[81].backends[6]));
+	_register_command_CCV_NNC_INDEX_SELECT_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[76].backends[6]));
+	_register_command_CCV_NNC_LEAKY_RELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[118].backends[6]));
+	_register_command_CCV_NNC_LEAKY_RELU_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[119].backends[6]));
+	_register_command_CCV_NNC_MSE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[20].backends[6]));
+	_register_command_CCV_NNC_LAYER_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[54].backends[6]));
+	_register_command_CCV_NNC_LAYER_NORM_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[55].backends[6]));
+	_register_command_CCV_NNC_GROUP_NORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[70].backends[6]));
+	_register_command_CCV_NNC_MAX_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[2].backends[6]));
+	_register_command_CCV_NNC_AVERAGE_POOL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[90].backends[6]));
+	_register_command_CCV_NNC_RANDOM_UNIFORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[8].backends[6]));
+	_register_command_CCV_NNC_RANDOM_NORMAL_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[50].backends[6]));
+	_register_command_CCV_NNC_REDUCE_SUM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[48].backends[6]));
+	_register_command_CCV_NNC_REDUCE_MEAN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[24].backends[6]));
+	_register_command_CCV_NNC_REDUCE_MAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[106].backends[6]));
+	_register_command_CCV_NNC_REDUCE_MIN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[112].backends[6]));
+	_register_command_CCV_NNC_ARGMAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[44].backends[6]));
+	_register_command_CCV_NNC_ARGMIN_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[78].backends[6]));
+	_register_command_CCV_NNC_RELU_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[12].backends[6]));
+	_register_command_CCV_NNC_SIGMOID_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[0].backends[6]));
+	_register_command_CCV_NNC_SIGMOID_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[1].backends[6]));
+	_register_command_CCV_NNC_SOFTMAX_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[114].backends[6]));
+	_register_command_CCV_NNC_SOFTMAX_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[115].backends[6]));
+	_register_command_CCV_NNC_SWISH_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[122].backends[6]));
+	_register_command_CCV_NNC_SWISH_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[123].backends[6]));
+	_register_command_CCV_NNC_UPSAMPLE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[86].backends[6]));
+	_register_command_CCV_NNC_SET_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[72].backends[6]));
+	_register_command_CCV_NNC_SET_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[73].backends[6]));
 	_register_command_CCV_NNC_DATA_TRANSFER_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[10].backends[6]));
 	_register_command_CCV_NNC_DATA_TRANSFER_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[11].backends[6]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[8].backends[6]));
-	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[9].backends[6]));
-	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[76].backends[6]));
-	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[77].backends[6]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[128].backends[6]));
-	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[129].backends[6]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[56].backends[6]));
+	_register_command_CCV_NNC_FORMAT_TRANSFORM_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[57].backends[6]));
+	_register_command_CCV_NNC_TRANSPOSE_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[46].backends[6]));
+	_register_command_CCV_NNC_TRANSPOSE_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[47].backends[6]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_FORWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[74].backends[6]));
+	_register_command_CCV_NNC_DATATYPE_CONVERSION_BACKWARD_backend_CCV_NNC_BACKEND_MPS(&(init_map[75].backends[6]));
 #endif
 }

--- a/lib/nnc/cmd/norm/mps/ccv_nnc_layer_norm_mps.m
+++ b/lib/nnc/cmd/norm/mps/ccv_nnc_layer_norm_mps.m
@@ -172,8 +172,8 @@ static int _ccv_nnc_layer_norm_back(const ccv_nnc_cmd_t cmd, const ccv_nnc_hint_
 						[dscale_axes addObject:@(i)];
 				}
 				//  dscalep2[x] += ahp[x] * gp1[x];
-          		MPSGraphTensor* gradBnMulTensor = [graph multiplicationWithPrimaryTensor:ah secondaryTensor:mps_g name:nil];
-				mps_dscale = [graph reductionSumWithTensor:gradBnMulTensor axes:dscale_axes name:nil];
+				MPSGraphTensor* dscale = [graph multiplicationWithPrimaryTensor:ah secondaryTensor:mps_g name:nil];
+				mps_dscale = [graph reductionSumWithTensor:dscale axes:dscale_axes name:nil];
 			}
 
 			if (dbias) {

--- a/lib/nnc/cmd/norm/mps/ccv_nnc_layer_norm_mps.m
+++ b/lib/nnc/cmd/norm/mps/ccv_nnc_layer_norm_mps.m
@@ -84,6 +84,172 @@ static int _ccv_nnc_layer_norm_forw(const ccv_nnc_cmd_t cmd, const ccv_nnc_hint_
 	return CCV_NNC_EXEC_SUCCESS;
 }
 
+static int _ccv_nnc_layer_norm_back(const ccv_nnc_cmd_t cmd, const ccv_nnc_hint_t hint, const int flags, ccv_nnc_tensor_t* const* const inputs, const int input_size, ccv_nnc_tensor_t* const* const outputs, const int output_size, ccv_nnc_stream_context_t* const stream_context)
+{
+	assert(input_size == 9);
+	assert(output_size >= 1);
+	
+	const ccv_nnc_tensor_view_t* g = (ccv_nnc_tensor_view_t*)inputs[0];
+	ccv_nnc_tensor_view_t* const a = (ccv_nnc_tensor_view_t*)inputs[3];
+	ccv_nnc_tensor_view_t* const scale = (ccv_nnc_tensor_view_t*)inputs[4];
+	ccv_nnc_tensor_view_t* const saved_mean = (ccv_nnc_tensor_view_t*)inputs[7];
+	ccv_nnc_tensor_view_t* const saved_inv_std = (ccv_nnc_tensor_view_t*)inputs[8];
+	ccv_nnc_tensor_view_t* const h = (ccv_nnc_tensor_view_t*)outputs[0];
+	ccv_nnc_tensor_view_t* const dscale = output_size > 1 ? (ccv_nnc_tensor_view_t*)outputs[1] : 0;
+	ccv_nnc_tensor_view_t* const dbias = output_size > 2 ? (ccv_nnc_tensor_view_t*)outputs[2] : 0;
+	assert(ccv_nnc_tensor_nd(g->info.dim) <= CCV_NNC_MAX_DIM + 2);
+	assert(ccv_nnc_tensor_nd(a->info.dim) <= CCV_NNC_MAX_DIM + 2);
+	assert(ccv_nnc_tensor_nd(h->info.dim) <= CCV_NNC_MAX_DIM + 2);
+	assert(CCV_IS_TENSOR_CONTIGUOUS(a));
+
+	// Assuming this is float 32.
+	int adim[CCV_NNC_MAX_DIM_ALLOC];
+	int rdim[CCV_NNC_MAX_DIM_ALLOC];
+	ccv_nnc_tensor_view_get_dim(a, adim);
+	ccv_nnc_tensor_view_get_dim(saved_mean, rdim);
+	int x;
+	int n = 1;
+	for (x = 0; x < CCV_NNC_MAX_DIM + 2; x++)
+		n *= adim[x];
+	for (x = 0; x < CCV_NNC_MAX_DIM + 2; x++)
+		n /= rdim[x];
+
+	const int a_nd = ccv_nnc_tensor_nd(a->info.dim);
+
+	@autoreleasepool {
+		MPSCommandBuffer* command_buffer = ccv_nnc_stream_context_start_mps_command_buffer(stream_context);
+		ccv_nnc_mps_graph_key_t key = ccv_nnc_mps_graph_key_new(cmd, hint, flags, inputs, input_size, outputs, output_size);
+		int indices[4];
+		MPSGraphExecutable* executable = ccv_nnc_mps_graph_executable_cache(key, indices, ^void (MPSGraph* graph, NSMutableArray<MPSGraphTensor*>* inputTensors, NSMutableArray<MPSGraphShapedType*>* inputShapedTypes, NSMutableArray<MPSGraphTensor*>* resultTensors) {
+			MPSGraphTensor* mps_input_g;
+			MPSGraphTensor* mps_g = ccv_nnc_mps_graph_tensor_input(graph, g, g->info.dim, g->stride, &mps_input_g);
+			[inputTensors addObject:mps_input_g];
+			MPSGraphShapedType* mps_g_shape = ccv_nnc_mps_graph_tensor_input_shape(g, g->info.dim, g->stride);
+			[inputShapedTypes addObject:mps_g_shape];
+
+			MPSGraphTensor* mps_input_a;
+			MPSGraphTensor* mps_a = ccv_nnc_mps_graph_tensor_input(graph, a, a->info.dim, a->stride, &mps_input_a);
+			[inputTensors addObject:mps_input_a];
+			MPSGraphShapedType* mps_a_shape = ccv_nnc_mps_graph_tensor_input_shape(a, a->info.dim, a->stride);
+			[inputShapedTypes addObject:mps_a_shape];
+
+			MPSGraphTensor* mps_input_scale;
+			MPSGraphTensor* mps_scale = ccv_nnc_mps_graph_tensor_input(graph, scale, scale->info.dim, scale->stride, &mps_input_scale);
+			[inputTensors addObject:mps_input_scale];
+			MPSGraphShapedType* mps_scale_shape = ccv_nnc_mps_graph_tensor_input_shape(scale, scale->info.dim, scale->stride);
+			[inputShapedTypes addObject:mps_scale_shape];
+
+			MPSGraphTensor* mps_input_saved_mean;
+			MPSGraphTensor* mps_saved_mean = ccv_nnc_mps_graph_tensor_input(graph, saved_mean, saved_mean->info.dim, saved_mean->stride, &mps_input_saved_mean);
+			[inputTensors addObject:mps_input_saved_mean];
+			MPSGraphShapedType* mps_saved_mean_shape = ccv_nnc_mps_graph_tensor_input_shape(saved_mean, saved_mean->info.dim, saved_mean->stride);
+			[inputShapedTypes addObject:mps_saved_mean_shape];
+
+			MPSGraphTensor* mps_input_saved_inv_std;
+			MPSGraphTensor* mps_saved_inv_std = ccv_nnc_mps_graph_tensor_input(graph, saved_inv_std, saved_inv_std->info.dim, saved_inv_std->stride, &mps_input_saved_inv_std);
+			[inputTensors addObject:mps_saved_inv_std];
+			MPSGraphShapedType* mps_saved_inv_std_shape = ccv_nnc_mps_graph_tensor_input_shape(saved_inv_std, saved_inv_std->info.dim, saved_inv_std->stride);
+			[inputShapedTypes addObject:mps_saved_inv_std_shape];
+
+			NSMutableArray<NSNumber*>* axes = [NSMutableArray new];			
+			for (int k = 0; k < cmd.info.lnorm.count; k++) {
+				[axes addObject:@(cmd.info.lnorm.axis[k])];
+			}
+
+			MPSGraphTensor* mps_dscale = nil;
+			MPSGraphTensor* mps_dbias = nil;
+			MPSGraphTensor* mps_h = nil;
+
+			// ap1[x] - meanp2[0]
+			MPSGraphTensor* x_minus_mean = [graph subtractionWithPrimaryTensor:mps_a secondaryTensor:mps_saved_mean name:nil];
+
+			// ahp[x] = (ap1[x] - meanp2[0]) * inv_stdp2[0];
+			MPSGraphTensor* ah = [graph multiplicationWithPrimaryTensor:x_minus_mean secondaryTensor:mps_saved_inv_std name:nil];
+			if (dscale) {
+				NSMutableArray<NSNumber*>* dscale_axes = [NSMutableArray new];	
+				for (int i = 0; i < a_nd; i++) {
+					if (a->info.dim[i] != dscale->info.dim[i])
+						[dscale_axes addObject:@(i)];
+				}
+				//  dscalep2[x] += ahp[x] * gp1[x];
+          		MPSGraphTensor* gradBnMulTensor = [graph multiplicationWithPrimaryTensor:ah secondaryTensor:mps_g name:nil];
+				mps_dscale = [graph reductionSumWithTensor:gradBnMulTensor axes:dscale_axes name:nil];
+			}
+
+			if (dbias) {
+				NSMutableArray<NSNumber*>* dbias_axes = [NSMutableArray new];	
+				for (int i = 0; i < a_nd; i++) {
+					if (a->info.dim[i] != dbias->info.dim[i])
+						[dbias_axes addObject:@(i)];
+				}
+				mps_dbias = [graph reductionSumWithTensor:mps_g axes:dbias_axes name:nil];
+			}
+
+			if (h) {							
+				// gp1[x] * scalep2[x]
+				mps_g = [graph multiplicationWithPrimaryTensor:mps_g secondaryTensor:mps_scale name:nil];
+
+				// inv_n 
+				MPSGraphTensor* sizeReciprocalTensor = [graph reciprocalWithTensor:[graph constantWithScalar:n dataType:mps_a.dataType] name:nil];          
+
+				// dscalep2[0] = ahp[x] * gp1[x] * scalep2[x];
+				MPSGraphTensor* bnGradMulTensor = [graph multiplicationWithPrimaryTensor:mps_g secondaryTensor:ah name:nil];
+				
+				// dscalep2[0] += ahp[x] * gp1[x] * scalep2[x]; reduce 
+				MPSGraphTensor* gammaGradient = [graph reductionSumWithTensor:bnGradMulTensor axes:axes name:nil];
+
+				// gp1[x] * scalep2[x]; reduce
+				MPSGraphTensor* betaGradient = [graph reductionSumWithTensor:mps_g axes:axes name:nil];
+
+				// gssp = gp1[x] * scalep2[x] * inv_stdp2[x]
+				MPSGraphTensor* gss = [graph multiplicationWithPrimaryTensor:mps_g secondaryTensor:mps_saved_inv_std name:nil];
+				
+				// ah[x] * gss[x]
+				MPSGraphTensor* ahgss = [graph multiplicationWithPrimaryTensor:ah secondaryTensor:gss name:nil];
+										
+				// ah[x] * gssp[x]; reduce
+				MPSGraphTensor* ahgssr = [graph reductionSumWithTensor:ahgss axes:axes name:nil];
+
+				// ahp[x] * ahgssrp2[x]
+				MPSGraphTensor* gssrp_ahp_ahgssrp = [graph multiplicationWithPrimaryTensor:ah secondaryTensor:ahgssr name:nil];
+
+				// gssr = gss reduce
+				MPSGraphTensor* gssr = [graph reductionSumWithTensor:gss axes:axes name:nil];
+
+				// gssrp2[x] + ahp[x] * ahgssrp2[x]
+				gssrp_ahp_ahgssrp = [graph additionWithPrimaryTensor:gssrp_ahp_ahgssrp secondaryTensor:gssr name:nil];
+
+				// inv_n * (gssrp2[x] + ahp[x] * ahgssrp2[x])
+				gssrp_ahp_ahgssrp = [graph multiplicationWithPrimaryTensor:gssrp_ahp_ahgssrp secondaryTensor:sizeReciprocalTensor name:nil]; 
+
+				// h = gssp[x] - inv_n * (gssrp2[x] + ahp[x] * ahgssrp2[x])
+				mps_h = [graph subtractionWithPrimaryTensor:gss secondaryTensor:gssrp_ahp_ahgssrp name:nil];	
+			}
+
+			if (mps_h) {
+				[resultTensors addObject:mps_h];
+			} 
+
+			if (mps_dscale) {
+				[resultTensors addObject:mps_dscale];
+			}
+
+			if (mps_dbias) {
+				[resultTensors addObject:mps_dbias];
+			}
+		});
+		MPSGraphTensorData* data_g = ccv_nnc_mps_graph_tensor_data(g, g->info.dim, g->stride);
+		MPSGraphTensorData* data_a = ccv_nnc_mps_graph_tensor_data(a, a->info.dim, a->stride);
+		MPSGraphTensorData* data_scale = ccv_nnc_mps_graph_tensor_data(scale, scale->info.dim, scale->stride);
+		MPSGraphTensorData* data_saved_mean = ccv_nnc_mps_graph_tensor_data(saved_mean, saved_mean->info.dim, saved_mean->stride);
+		MPSGraphTensorData* data_saved_inv_std = ccv_nnc_mps_graph_tensor_data(saved_inv_std, saved_inv_std->info.dim, saved_inv_std->stride);
+
+		ccv_nnc_mps_graph_executable_result(executable, command_buffer, @[data_g, data_a, data_scale, data_saved_mean, data_saved_inv_std], (ccv_nnc_tensor_view_t* []){ h, dscale, dbias }, (int*[]){ h->info.dim, dscale->info.dim, dbias->info.dim }, (int*[]){ h->stride, dscale->stride, dbias->stride }, 3);
+		ccv_nnc_stream_context_finish_mps_command_buffer(stream_context, command_buffer);
+	}
+	return CCV_NNC_EXEC_SUCCESS;
+}
+
 REGISTER_COMMAND_BACKEND(CCV_NNC_LAYER_NORM_FORWARD, CCV_NNC_BACKEND_MPS)(ccv_nnc_cmd_backend_registry_t* const registry)
 {
 	registry->tensor_formats = CCV_TENSOR_FORMAT_NCHW | CCV_TENSOR_FORMAT_NHWC | CCV_TENSOR_FORMAT_CHWN;
@@ -91,4 +257,13 @@ REGISTER_COMMAND_BACKEND(CCV_NNC_LAYER_NORM_FORWARD, CCV_NNC_BACKEND_MPS)(ccv_nn
 	registry->tensor_memory = CCV_TENSOR_GPU_MEMORY;
 	registry->algorithms = 1;
 	registry->exec = _ccv_nnc_layer_norm_forw;
+}
+
+REGISTER_COMMAND_BACKEND(CCV_NNC_LAYER_NORM_BACKWARD, CCV_NNC_BACKEND_MPS)(ccv_nnc_cmd_backend_registry_t* const registry)
+{
+	registry->tensor_formats = CCV_TENSOR_FORMAT_NCHW | CCV_TENSOR_FORMAT_NHWC | CCV_TENSOR_FORMAT_CHWN;
+	registry->tensor_datatypes = CCV_32F | CCV_16F;
+	registry->tensor_memory = CCV_TENSOR_GPU_MEMORY;
+	registry->algorithms = 1;
+	registry->exec = _ccv_nnc_layer_norm_back;
 }

--- a/test/int/nnc/mpsdnn.tests.c
+++ b/test/int/nnc/mpsdnn.tests.c
@@ -22,6 +22,8 @@ TEST_SETUP()
 
 #define BATCH_SIZE (64)
 
+#define LN_DIM (10)
+
 TEST_CASE("mps forward convolution")
 {
 	GUARD_ELSE_RETURN(ccv_nnc_cmd_ok(CCV_NNC_CONVOLUTION_FORWARD, CCV_NNC_BACKEND_MPS));
@@ -1502,6 +1504,114 @@ TEST_CASE("mps leaky relu gradient in float")
 	ccv_nnc_tensor_arena_free(tensor_arena);
 	ccv_nnc_graph_exec_arena_free(graph_exec_arena);
 	ccv_nnc_symbolic_graph_free(symbolic_graph);
+}
+
+TEST_CASE("compare layernorm gradient with mps")
+{
+	GUARD_ELSE_RETURN(ccv_nnc_cmd_ok(CCV_NNC_LAYER_NORM_FORWARD, CCV_NNC_BACKEND_MPS) &&
+		ccv_nnc_cmd_ok(CCV_NNC_LAYER_NORM_BACKWARD, CCV_NNC_BACKEND_MPS) &&
+		(ccv_nnc_cmd_ok(CCV_NNC_SET_FORWARD, CCV_NNC_BACKEND_MPS) || ccv_nnc_cmd_ok(CCV_NNC_SET_FORWARD, CCV_NNC_BACKEND_MPS)));
+	ccv_nnc_symbolic_graph_t* const symbolic_graph = ccv_nnc_symbolic_graph_new();
+	ccv_nnc_tensor_symbol_t bx = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 2, 2, 2, LN_DIM), "x");
+	ccv_nnc_tensor_symbol_t by = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 2, 2, 2, LN_DIM), "y");
+	ccv_nnc_tensor_symbol_t scale = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 1, 2, 2, LN_DIM), "scale");
+	ccv_nnc_tensor_symbol_t bias = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 1, 2, 2, LN_DIM), "bias");
+	ccv_nnc_tensor_symbol_t saved_mean = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 2, 1, 1, 1), "saved_mean");
+	ccv_nnc_tensor_symbol_t saved_inv_std = ccv_nnc_tensor_symbol_new(symbolic_graph, GPU_TENSOR_NHWC(000, 32F, 2, 1, 1, 1), "saved_inv_std");
+	ccv_nnc_graph_exec_symbol_new(symbolic_graph, CMD_LAYER_NORM_FORWARD(1e-4, 1, 2, 3), TENSOR_SYMBOL_LIST(bx, scale, bias), TENSOR_SYMBOL_LIST(by, saved_mean, saved_inv_std), "layer_norm");
+	ccv_nnc_graph_exec_symbol_autogen(symbolic_graph, 0, 0, CCV_NNC_AUTOGEN_ALL_EXECS | CCV_NNC_AUTOGEN_SOURCES_AND_DESTINATIONS);
+	ccv_nnc_symbolic_graph_backward(symbolic_graph, TENSOR_SYMBOL_LIST(by), TENSOR_SYMBOL_LIST(bx, scale, bias), SYMBOLIC_GRAPH_SOURCES(symbolic_graph), SYMBOLIC_GRAPH_DESTINATIONS(symbolic_graph));
+	ccv_nnc_graph_exec_symbol_autogen(symbolic_graph, 0, 0, CCV_NNC_AUTOGEN_ALL_EXECS | CCV_NNC_AUTOGEN_SOURCES_AND_DESTINATIONS);
+	ccv_nnc_tensor_symbol_t dby = ccv_nnc_tensor_symbol_for_backward(symbolic_graph, by);
+	ccv_nnc_tensor_symbol_t dbx = ccv_nnc_tensor_symbol_for_backward(symbolic_graph, bx);
+	ccv_nnc_graph_t* graph = 0;
+	ccv_nnc_tensor_arena_t* tensor_arena = 0;
+	ccv_nnc_graph_exec_arena_t* graph_exec_arena = 0;
+	ccv_nnc_symbolic_graph_compile(symbolic_graph, ccv_nnc_default_compile_params, 0, 0, 0, 0, SYMBOLIC_GRAPH_SOURCES(symbolic_graph), SYMBOLIC_GRAPH_DESTINATIONS(symbolic_graph), &graph, &tensor_arena, &graph_exec_arena);
+	SYMBOLIC_GRAPH_GEN(symbolic_graph, CCV_NNC_LONG_DOT_GRAPH);
+	GRAPH_GEN(graph, CCV_NNC_LONG_DOT_GRAPH);
+	ccv_nnc_tensor_t* const bx_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, bx);
+	dsfmt_t dsfmt;
+	ccv_nnc_tensor_t* const x_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), 0);
+	int i;
+	dsfmt_init_gen_rand(&dsfmt, 1);
+	for (i = 0; i < 2 * 2 * 2 * LN_DIM; i++)
+		x_tensor->data.f32[i] = dsfmt_genrand_open_close(&dsfmt) * 100;
+
+	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(x_tensor), TENSOR_LIST(bx_tensor), 0);
+	float scaledata[1 * 2 * 2 * LN_DIM];
+	float biasdata[1 * 2 * 2 * LN_DIM];
+	for (i = 0; i < 1 * 2 * 2 * LN_DIM; i++)
+		scaledata[i] = dsfmt_genrand_open_close(&dsfmt);
+	for (i = 0; i < 1 * 2 * 2 * LN_DIM; i++)
+		biasdata[i] = dsfmt_genrand_open_close(&dsfmt);
+
+	ccv_nnc_tensor_t scale_tensor = ccv_nnc_tensor(scaledata, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
+	ccv_nnc_tensor_t bias_tensor = ccv_nnc_tensor(biasdata, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
+	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(&scale_tensor, &bias_tensor), TENSOR_LIST(ccv_nnc_tensor_from_symbol(tensor_arena, scale), ccv_nnc_tensor_from_symbol(tensor_arena, bias)), 0);
+	ccv_nnc_graph_run(graph, 0, TRAVERSE_FULL, 0, 0);
+	ccv_nnc_tensor_t* const dy_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), 0);
+	ccv_nnc_tensor_t* const dby_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, dby);
+	for (i = 0; i < 2 * 2 * 2 * LN_DIM; i++)
+		dy_tensor->data.f32[i] = dsfmt_genrand_open_close(&dsfmt) * 2 - 1;
+	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(dy_tensor), TENSOR_LIST(dby_tensor), 0);
+	ccv_nnc_graph_run(graph, 0, TRAVERSE_FULL, 0, 0);
+	ccv_nnc_tensor_t* const dbx_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, dbx);
+	ccv_nnc_tensor_t* const dx_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), 0);
+	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(dbx_tensor), TENSOR_LIST(dx_tensor), 0);
+	ccv_nnc_tensor_t* const dbscale_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, ccv_nnc_tensor_symbol_for_backward(symbolic_graph, scale));
+	ccv_nnc_tensor_t* const dbbias_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, ccv_nnc_tensor_symbol_for_backward(symbolic_graph, bias));
+	ccv_nnc_tensor_t* const dscale_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
+	ccv_nnc_tensor_t* const dbias_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
+	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(dbscale_tensor, dbbias_tensor), TENSOR_LIST(dscale_tensor, dbias_tensor), 0);
+	ccv_nnc_symbolic_graph_free(symbolic_graph);
+	ccv_nnc_tensor_arena_free(tensor_arena);
+	ccv_nnc_graph_exec_arena_free(graph_exec_arena);
+	ccv_nnc_graph_free(graph);
+	ccv_nnc_symbolic_graph_t* const cpu_symbolic_graph = ccv_nnc_symbolic_graph_new();
+	ccv_nnc_tensor_symbol_t cx = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), "x");
+	ccv_nnc_tensor_symbol_t cy = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), "y");
+	ccv_nnc_tensor_symbol_t cscale = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), "scale");
+	ccv_nnc_tensor_symbol_t cbias = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), "bias");
+	ccv_nnc_tensor_symbol_t csaved_mean = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 2, 1, 1, 1), "saved_mean");
+	ccv_nnc_tensor_symbol_t csaved_inv_std = ccv_nnc_tensor_symbol_new(cpu_symbolic_graph, CPU_TENSOR_NHWC(32F, 2, 1, 1, 1), "saved_inv_std");
+	ccv_nnc_graph_exec_symbol_new(cpu_symbolic_graph, CMD_LAYER_NORM_FORWARD(1e-4, 1, 2, 3), TENSOR_SYMBOL_LIST(cx, cscale, cbias), TENSOR_SYMBOL_LIST(cy, csaved_mean, csaved_inv_std), "layer_norm");
+	ccv_nnc_graph_exec_symbol_autogen(cpu_symbolic_graph, 0, 0, CCV_NNC_AUTOGEN_ALL_EXECS | CCV_NNC_AUTOGEN_SOURCES_AND_DESTINATIONS);
+	ccv_nnc_symbolic_graph_backward(cpu_symbolic_graph, TENSOR_SYMBOL_LIST(cy), TENSOR_SYMBOL_LIST(cx, cscale, cbias), SYMBOLIC_GRAPH_SOURCES(cpu_symbolic_graph), SYMBOLIC_GRAPH_DESTINATIONS(cpu_symbolic_graph));
+	ccv_nnc_graph_exec_symbol_autogen(cpu_symbolic_graph, 0, 0, CCV_NNC_AUTOGEN_ALL_EXECS | CCV_NNC_AUTOGEN_SOURCES_AND_DESTINATIONS);
+	ccv_nnc_tensor_symbol_t dcy = ccv_nnc_tensor_symbol_for_backward(cpu_symbolic_graph, cy);
+	ccv_nnc_tensor_symbol_t dcx = ccv_nnc_tensor_symbol_for_backward(cpu_symbolic_graph, cx);
+	ccv_nnc_tensor_symbol_t dcscale = ccv_nnc_tensor_symbol_for_backward(cpu_symbolic_graph, cscale);
+	ccv_nnc_tensor_symbol_t dcbias = ccv_nnc_tensor_symbol_for_backward(cpu_symbolic_graph, cbias);
+	ccv_nnc_graph_t* cpu_graph = 0;
+	ccv_nnc_tensor_arena_t* cpu_tensor_arena = 0;
+	ccv_nnc_graph_exec_arena_t* cpu_graph_exec_arena = 0;
+	ccv_nnc_symbolic_graph_compile(cpu_symbolic_graph, ccv_nnc_default_compile_params, 0, 0, 0, 0, SYMBOLIC_GRAPH_SOURCES(cpu_symbolic_graph), SYMBOLIC_GRAPH_DESTINATIONS(cpu_symbolic_graph), &cpu_graph, &cpu_tensor_arena, &cpu_graph_exec_arena);
+	ccv_nnc_tensor_t* const cx_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, cx);
+	memcpy(cx_tensor->data.f32, x_tensor->data.f32, sizeof(float) * 2 * 2 * 2 * LN_DIM);
+	ccv_nnc_tensor_t* const dcy_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, dcy);
+	memcpy(dcy_tensor->data.f32, dy_tensor->data.f32, sizeof(float) * 2 * 2 * 2 * LN_DIM);
+	ccv_nnc_tensor_t* const cscale_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, cscale);
+	memcpy(cscale_tensor->data.f32, scaledata, sizeof(float) * 1 * 2 * 2 * LN_DIM);
+	ccv_nnc_tensor_t* const cbias_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, cbias);
+	memcpy(cbias_tensor->data.f32, biasdata, sizeof(float) * 1 * 2 * 2 * LN_DIM);
+	ccv_nnc_graph_run(cpu_graph, 0, TRAVERSE_FULL, 0, 0);
+	ccv_nnc_tensor_t* const dcscale_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, dcscale);
+	ccv_nnc_tensor_t* const dcbias_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, dcbias);
+	ccv_nnc_tensor_t* const dcx_tensor = ccv_nnc_tensor_from_symbol(cpu_tensor_arena, dcx);
+
+	REQUIRE_TENSOR_EQ(dx_tensor, dcx_tensor, "layer norm gradient result from cudnn should match the one from reference implementation");
+	REQUIRE_TENSOR_EQ(dscale_tensor, dcscale_tensor, "layer norm scale gradient result from cudnn should match the one from reference implementation");
+	REQUIRE_TENSOR_EQ(dbias_tensor, dcbias_tensor, "layer norm bias gradient result from cudnn should match the one from reference implementation");
+	ccv_nnc_symbolic_graph_free(cpu_symbolic_graph);
+	ccv_nnc_tensor_arena_free(cpu_tensor_arena);
+	ccv_nnc_graph_exec_arena_free(cpu_graph_exec_arena);
+	ccv_nnc_graph_free(cpu_graph);
+	ccv_nnc_tensor_free(x_tensor);
+	ccv_nnc_tensor_free(dy_tensor);
+	ccv_nnc_tensor_free(dx_tensor);
+	ccv_nnc_tensor_free(dscale_tensor);
+	ccv_nnc_tensor_free(dbias_tensor);
 }
 
 #include "case_main.h"

--- a/test/int/nnc/mpsdnn.tests.c
+++ b/test/int/nnc/mpsdnn.tests.c
@@ -1549,7 +1549,6 @@ TEST_CASE("compare layernorm gradient with mps")
 	ccv_nnc_tensor_t scale_tensor = ccv_nnc_tensor(scaledata, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
 	ccv_nnc_tensor_t bias_tensor = ccv_nnc_tensor(biasdata, CPU_TENSOR_NHWC(32F, 1, 2, 2, LN_DIM), 0);
 	ccv_nnc_cmd_exec(CMD_DATA_TRANSFER_FORWARD(), ccv_nnc_no_hint, 0, TENSOR_LIST(&scale_tensor, &bias_tensor), TENSOR_LIST(ccv_nnc_tensor_from_symbol(tensor_arena, scale), ccv_nnc_tensor_from_symbol(tensor_arena, bias)), 0);
-	ccv_nnc_graph_run(graph, 0, TRAVERSE_FULL, 0, 0);
 	ccv_nnc_tensor_t* const dy_tensor = ccv_nnc_tensor_new(0, CPU_TENSOR_NHWC(32F, 2, 2, 2, LN_DIM), 0);
 	ccv_nnc_tensor_t* const dby_tensor = ccv_nnc_tensor_from_symbol(tensor_arena, dby);
 	for (i = 0; i < 2 * 2 * 2 * LN_DIM; i++)


### PR DESCRIPTION
Implement with added tests. 
Aligned with layer_norm_cpu_ref.c variable name 
Compare to Pytorch implementation, removed redundant computation(reuse) for 
ahp[x] = (ap1[x] - meanp2[0]) * inv_stdp2[0];


![Screenshot 2023-08-01 at 12 27 51 PM](https://github.com/liuliu/ccv/assets/18563592/0d08858d-c9ba-482a-a41e-8919185f2cfa)
