### PR TITLE
create buffer if matrix length larger than 4096

### DIFF
--- a/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
+++ b/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
@@ -111,7 +111,7 @@ void ccv_nnc_mfa_encode_gemm(mfa::context* context, ccv_nnc_mfa_gemm_params_t pa
     }
     if (batch_size * 32 > 4096) {
         auto buffer = context->device->newBuffer(matrix_offsets, batch_size * 32, MTL::ResourceStorageModeShared);
-        encoder->useResource(buffer, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
+        encoder->useResource(buffer, MTL::ResourceUsageRead);
         encoder->setBuffer(buffer, 0, 10);
         buffer->release();
     } else {

--- a/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
+++ b/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
@@ -111,6 +111,7 @@ void ccv_nnc_mfa_encode_gemm(mfa::context* context, ccv_nnc_mfa_gemm_params_t pa
     }
     if (batch_size * 32 > 4096) {
         auto buffer = context->device->newBuffer(matrix_offsets, batch_size * 32, MTL::ResourceStorageModeShared);
+        encoder->useResource(buffer, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
         encoder->setBuffer(buffer, 0, 10);
         buffer->release();
     } else {

--- a/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
+++ b/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
@@ -110,15 +110,9 @@ void ccv_nnc_mfa_encode_gemm(mfa::context* context, ccv_nnc_mfa_gemm_params_t pa
       };
     }
     if (batch_size * 32 > 4096) {
-#ifdef __x86_64__
-          auto buffer = context->device->newBuffer(batch_size * 32, MTL::ResourceStorageModePrivate);
-#else
-          auto buffer = context->device->newBuffer(batch_size * 32, MTL::ResourceStorageModeShared);
-#endif
-          void* bufferPointer = buffer->contents();
-          memcpy(bufferPointer, matrix_offsets, batch_size * 32);
-          encoder->setBuffer(buffer, 0, 10);
-          buffer->release();
+        auto buffer = context->device->newBuffer(matrix_offsets, batch_size * 32, MTL::ResourceStorageModeShared);
+        encoder->setBuffer(buffer, 0, 10);
+        buffer->release();
     } else {
         encoder->setBytes(matrix_offsets, batch_size * 32, 10);
     }

--- a/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
+++ b/lib/nnc/mfa/ccv_nnc_mfa_gemm.cpp
@@ -109,7 +109,12 @@ void ccv_nnc_mfa_encode_gemm(mfa::context* context, ccv_nnc_mfa_gemm_params_t pa
         i * byte_stride_d,
       };
     }
-    encoder->setBytes(matrix_offsets, batch_size * 32, 10);
+    if (batch_size * 32 > 4096) {
+        auto buffer = context->device->newBuffer(matrix_offsets, batch_size * 32, MTL::ResourceStorageModeShared);
+        encoder->setBuffer(buffer, 0, 10);
+    } else {
+        encoder->setBytes(matrix_offsets, batch_size * 32, 10);
+    }
   }
   
   auto grid_size = pipeline->grid_size;


### PR DESCRIPTION

fallback for 
"-[MTLDebugComputeCommandEncoder setBytes:length:attributeStride:atIndex:]:400: failed assertion `length(X) must be <= 4096.'"
MTLDebugComputeCommandEncoder setBytes can only support 4096

tested on DT 