### PR TITLE
Add -1 dimension support in cnnp reshape

### DIFF
--- a/lib/nnc/ccv_cnnp_model_addons.c
+++ b/lib/nnc/ccv_cnnp_model_addons.c
@@ -605,17 +605,17 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 	int stride_from_dim[CCV_NNC_MAX_DIM_ALLOC];
 	if (to.d == CCV_NNC_NO_TENSOR_SYMBOL) // If we are not reshape an alias, it is straightforward.
 	{
-                memcpy(params.dim, dim, sizeof(params.dim));
+		memcpy(params.dim, dim, sizeof(params.dim));
 		int* stride;
 		if (self->stride[0] == 0)
 		{
-                        ccv_nnc_tensor_get_stride(dim, stride_from_dim);
+			ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 			stride = stride_from_dim;
 		} else
 			stride = self->stride;
 		if (self->format > 0)
 			params.format = self->format;
-                outputs[0] = ccv_nnc_tensor_symbol_alias_new(graph, inputs[0], self->ofs, stride, params, 0);
+		outputs[0] = ccv_nnc_tensor_symbol_alias_new(graph, inputs[0], self->ofs, stride, params, 0);
 	} else {
 		// Otherwise, we need to check if it is permute. For permute, we cannot do alias directly.
 		// We need to first materialize the permute and then run reshape on top of it, otherwise it will be wrong.
@@ -624,7 +624,7 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 		// We identify permute by checking if the stride is not in descending order.
 		// This also covered "permute" through reshape, rather than using ccv_cnnp_permute directly.
 		const int nd = ccv_nnc_tensor_nd(params.dim);
-                const int new_nd = ccv_nnc_tensor_nd(dim);
+		const int new_nd = ccv_nnc_tensor_nd(dim);
 		int i, no_permute = 1;
 		// If the new dim has different nd, or we actually have a stride, we need to check if it is no permute or not.
 		if (new_nd != nd || (self->stride[0] != 0 && memcmp(self->stride, old_stride, sizeof(self->stride))))
@@ -633,13 +633,13 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 					no_permute = 0;
 		if (no_permute)
 		{ // Just straightforward reshape if there is no no permute.
-                        memcpy(params.dim, dim, sizeof(params.dim));
+			memcpy(params.dim, dim, sizeof(params.dim));
 			int* stride;
 			if (self->stride[0] == 0)
 			{
 				if (new_nd != nd) // Cannot use old stride.
 				{
-                                        ccv_nnc_tensor_get_stride(dim, stride_from_dim);
+					ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 					stride = stride_from_dim;
 				} else
 					stride = old_stride;
@@ -652,11 +652,11 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 			// Otherwise, we first do format transform to plain tensor and then do reshape.
 			ccv_nnc_tensor_symbol_t permuted = ccv_nnc_tensor_symbol_new(graph, params, 0);
 			ccv_nnc_graph_exec_symbol_new(graph, CMD_FORMAT_TRANSFORM_FORWARD(), TENSOR_SYMBOL_LIST(inputs[0]), TENSOR_SYMBOL_LIST(permuted), "reshape");
-                        memcpy(params.dim, dim, sizeof(params.dim));
+			memcpy(params.dim, dim, sizeof(params.dim));
 			int* stride;
 			if (self->stride[0] == 0)
 			{
-                                ccv_nnc_tensor_get_stride(dim, stride_from_dim);
+				ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 				stride = stride_from_dim;
 			} else
 				stride = self->stride;

--- a/lib/nnc/ccv_cnnp_model_addons.c
+++ b/lib/nnc/ccv_cnnp_model_addons.c
@@ -577,6 +577,21 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 		PRINT(CCV_CLI_VERBOSE, ")\n");
 	}
 	ccv_nnc_tensor_param_t params = ccv_nnc_tensor_symbol_params(graph, inputs[0]);
+	int dim[CCV_NNC_MAX_DIM_ALLOC];
+	memcpy(dim, self->dim, sizeof(dim));
+	int i, auto_idx = -1;
+	size_t known = 1;
+	const size_t tensor_count = ccv_nnc_tensor_count(params);
+	for (i = 0; i < CCV_NNC_MAX_DIM_ALLOC && dim[i]; i++)
+		if (dim[i] == -1)
+			auto_idx = i;
+		else
+			known *= dim[i];
+	if (auto_idx >= 0)
+	{
+		assert(known > 0 && tensor_count % known == 0);
+		dim[auto_idx] = tensor_count / known;
+	}
 	if (CCV_CLI_OUTPUT_LEVEL_IS(CCV_CLI_VERBOSE))
 	{
 		PRINT(CCV_CLI_VERBOSE, "[cnnp_reshape_build] 2. input: (%d", params.dim[0]);
@@ -585,22 +600,22 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 			PRINT(CCV_CLI_VERBOSE, ", %d", params.dim[i]);
 		PRINT(CCV_CLI_VERBOSE, ")\n");
 	}
-	assert(ccv_nnc_dimension_count(self->dim) <= ccv_nnc_tensor_count(params));
+	assert(ccv_nnc_dimension_count(dim) <= ccv_nnc_tensor_count(params));
 	ccv_nnc_tensor_symbol_t to = ccv_nnc_tensor_symbol_alias_to(graph, inputs[0]);
 	int stride_from_dim[CCV_NNC_MAX_DIM_ALLOC];
 	if (to.d == CCV_NNC_NO_TENSOR_SYMBOL) // If we are not reshape an alias, it is straightforward.
 	{
-		memcpy(params.dim, self->dim, sizeof(params.dim));
+                memcpy(params.dim, dim, sizeof(params.dim));
 		int* stride;
 		if (self->stride[0] == 0)
 		{
-			ccv_nnc_tensor_get_stride(self->dim, stride_from_dim);
+                        ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 			stride = stride_from_dim;
 		} else
 			stride = self->stride;
 		if (self->format > 0)
 			params.format = self->format;
-		outputs[0] = ccv_nnc_tensor_symbol_alias_new(graph, inputs[0], self->ofs, stride, params, 0);
+                outputs[0] = ccv_nnc_tensor_symbol_alias_new(graph, inputs[0], self->ofs, stride, params, 0);
 	} else {
 		// Otherwise, we need to check if it is permute. For permute, we cannot do alias directly.
 		// We need to first materialize the permute and then run reshape on top of it, otherwise it will be wrong.
@@ -609,7 +624,7 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 		// We identify permute by checking if the stride is not in descending order.
 		// This also covered "permute" through reshape, rather than using ccv_cnnp_permute directly.
 		const int nd = ccv_nnc_tensor_nd(params.dim);
-		const int new_nd = ccv_nnc_tensor_nd(self->dim);
+                const int new_nd = ccv_nnc_tensor_nd(dim);
 		int i, no_permute = 1;
 		// If the new dim has different nd, or we actually have a stride, we need to check if it is no permute or not.
 		if (new_nd != nd || (self->stride[0] != 0 && memcmp(self->stride, old_stride, sizeof(self->stride))))
@@ -618,13 +633,13 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 					no_permute = 0;
 		if (no_permute)
 		{ // Just straightforward reshape if there is no no permute.
-			memcpy(params.dim, self->dim, sizeof(params.dim));
+                        memcpy(params.dim, dim, sizeof(params.dim));
 			int* stride;
 			if (self->stride[0] == 0)
 			{
 				if (new_nd != nd) // Cannot use old stride.
 				{
-					ccv_nnc_tensor_get_stride(self->dim, stride_from_dim);
+                                        ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 					stride = stride_from_dim;
 				} else
 					stride = old_stride;
@@ -637,11 +652,11 @@ static void _ccv_cnnp_reshape_build(ccv_cnnp_model_t* const super, ccv_nnc_symbo
 			// Otherwise, we first do format transform to plain tensor and then do reshape.
 			ccv_nnc_tensor_symbol_t permuted = ccv_nnc_tensor_symbol_new(graph, params, 0);
 			ccv_nnc_graph_exec_symbol_new(graph, CMD_FORMAT_TRANSFORM_FORWARD(), TENSOR_SYMBOL_LIST(inputs[0]), TENSOR_SYMBOL_LIST(permuted), "reshape");
-			memcpy(params.dim, self->dim, sizeof(params.dim));
+                        memcpy(params.dim, dim, sizeof(params.dim));
 			int* stride;
 			if (self->stride[0] == 0)
 			{
-				ccv_nnc_tensor_get_stride(self->dim, stride_from_dim);
+                                ccv_nnc_tensor_get_stride(dim, stride_from_dim);
 				stride = stride_from_dim;
 			} else
 				stride = self->stride;

--- a/test/unit/nnc/dynamic.graph.tests.c
+++ b/test/unit/nnc/dynamic.graph.tests.c
@@ -1156,7 +1156,30 @@ TEST_CASE("compute f(x) = exp(0.5 * log(x)), detach log(x) won't free exp(_)")
 	REQUIRE_EQ(ccv_nnc_dynamic_graph_bookkeeping_count(graph, CCV_NNC_SYMBOL_TENSOR), 1, "y should be freed");
 	ccv_nnc_tensor_variable_free(graph, x);
 	REQUIRE_EQ(ccv_nnc_dynamic_graph_bookkeeping_count(graph, CCV_NNC_SYMBOL_TENSOR), 0, "x should be freed");
+        ccv_nnc_dynamic_graph_free(graph);
+}
+
+TEST_CASE("cnnp reshape supports -1 dimension")
+{
+	ccv_cnnp_model_t* const reshape = ccv_cnnp_reshape(0, DIM_ALLOC(-1, 4), DIM_ALLOC(), DIM_ALLOC(), 0);
+	ccv_nnc_dynamic_graph_t* const graph = ccv_nnc_dynamic_graph_new();
+	ccv_nnc_tensor_variable_t x = ccv_nnc_tensor_variable_new(graph, CPU_TENSOR_NHWC(32F, 2, 3, 4));
+	int i;
+	for (i = 0; i < 2 * 3 * 4; i++)
+		ccv_nnc_tensor_from_variable(graph, x)->data.f32[i] = i;
+	const ccv_nnc_tensor_param_t input = CPU_TENSOR_NHWC(32F, 2, 3, 4);
+	ccv_cnnp_model_compile(reshape, &input, 1, CMD_NOOP(), CMD_NOOP());
+	ccv_nnc_tensor_variable_t y = ccv_nnc_tensor_variable_new(graph);
+	ccv_nnc_dynamic_graph_evaluate(graph, reshape, 0, TENSOR_VARIABLE_LIST(x), TENSOR_VARIABLE_LIST(y), 0, 0);
+	REQUIRE_EQ(ccv_nnc_tensor_from_variable(graph, y)->info.dim[0], 6, "dim inference");
+	REQUIRE_EQ(ccv_nnc_tensor_from_variable(graph, y)->info.dim[1], 4, "dim inference");
+	float btp[24];
+	for (i = 0; i < 24; i++)
+		btp[i] = i;
+	ccv_nnc_tensor_t bt = ccv_nnc_tensor(btp, CPU_TENSOR_NHWC(32F, 6, 4), 0);
+	REQUIRE_TENSOR_EQ(ccv_nnc_tensor_from_variable(graph, y), &bt, "reshape correctness");
 	ccv_nnc_dynamic_graph_free(graph);
+	ccv_cnnp_model_free(reshape);
 }
 
 #include "case_main.h"

--- a/test/unit/nnc/dynamic.graph.tests.c
+++ b/test/unit/nnc/dynamic.graph.tests.c
@@ -1156,7 +1156,7 @@ TEST_CASE("compute f(x) = exp(0.5 * log(x)), detach log(x) won't free exp(_)")
 	REQUIRE_EQ(ccv_nnc_dynamic_graph_bookkeeping_count(graph, CCV_NNC_SYMBOL_TENSOR), 1, "y should be freed");
 	ccv_nnc_tensor_variable_free(graph, x);
 	REQUIRE_EQ(ccv_nnc_dynamic_graph_bookkeeping_count(graph, CCV_NNC_SYMBOL_TENSOR), 0, "x should be freed");
-        ccv_nnc_dynamic_graph_free(graph);
+	ccv_nnc_dynamic_graph_free(graph);
 }
 
 TEST_CASE("cnnp reshape supports -1 dimension")


### PR DESCRIPTION
## Summary
- allow ccv_cnnp_reshape to infer one dimension
- add unit test for -1 dimension usage
- fix tabs for coding style

## Testing
- `make -C test/unit/nnc` *(fails: ../../../lib/config.mk: No such file or directory)*