### PR TITLE
Use size_t for tensor_count in CPU util kernels

### DIFF
--- a/lib/nnc/cmd/util/ccv_nnc_util_cpu_ref.c
+++ b/lib/nnc/cmd/util/ccv_nnc_util_cpu_ref.c
@@ -326,7 +326,8 @@ void _ccv_nnc_tensor_set_cpu_ref_f16(ccv_nnc_tensor_view_t* const a, const float
 	if (!CCV_IS_TENSOR_VIEW(a))
 	{
 		// Super optimal case, just do one for-loop for sum.
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			a->data.f16[x].v = h;
 		return;
@@ -397,7 +398,8 @@ void _ccv_nnc_tensor_set_cpu_ref_bf16(ccv_nnc_tensor_view_t* const a, const floa
 	if (!CCV_IS_TENSOR_VIEW(a))
 	{
 		// Super optimal case, just do one for-loop for sum.
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			a->data.f16[x].v = h;
 		return;
@@ -466,7 +468,8 @@ void _ccv_nnc_tensor_set_cpu_ref_f32(ccv_nnc_tensor_view_t* const a, const float
 	if (!CCV_IS_TENSOR_VIEW(a))
 	{
 		// Super optimal case, just do one for-loop for sum.
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			a->data.f32[x] = b;
 		return;
@@ -535,7 +538,8 @@ void _ccv_nnc_tensor_set_cpu_ref_f64(ccv_nnc_tensor_view_t* const a, const doubl
 	if (!CCV_IS_TENSOR_VIEW(a))
 	{
 		// Super optimal case, just do one for-loop for sum.
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			a->data.f64[x] = b;
 		return;
@@ -604,7 +608,8 @@ void _ccv_nnc_tensor_set_cpu_ref_i32(ccv_nnc_tensor_view_t* const a, const int b
 	if (!CCV_IS_TENSOR_VIEW(a))
 	{
 		// Super optimal case, just do one for-loop for sum.
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			a->data.i32[x] = b;
 		return;
@@ -1297,7 +1302,7 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 		} else if (a->info.datatype == CCV_16F && b->info.datatype == CCV_32F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
 			ccv_half_precision_to_float((uint16_t*)a->data.f16, b->data.f32, tensor_count);
 		} else if (a->info.datatype == CCV_64F && b->info.datatype == CCV_32F) {
@@ -1305,14 +1310,15 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
 			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
-			int i;
+			size_t i;
 			for (i = 0; i < tensor_count; i++)
 				b->data.f32[i] = (float)a->data.f64[i];
 		} else if (a->info.datatype == CCV_32F && b->info.datatype == CCV_64F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
+			size_t i;
 			for (i = 0; i < tensor_count; i++)
 				b->data.f64[i] = (double)a->data.f32[i];
 		} else if (a->info.datatype == CCV_64F && b->info.datatype == CCV_16F) {
@@ -1324,7 +1330,7 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 		} else if (a->info.datatype == CCV_16F && b->info.datatype == CCV_64F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
 			ccv_half_precision_to_double((uint16_t*)a->data.f16, b->data.f64, tensor_count);
 		} else if (a->info.datatype == CCV_16F && b->info.datatype == CCV_16BF) {
@@ -1336,7 +1342,7 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 		} else if (a->info.datatype == CCV_16BF && b->info.datatype == CCV_16F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
 			ccv_bfloat_to_half_precision((uint16_t*)a->data.f16, (uint16_t*)b->data.f16, tensor_count);
 		} else if (a->info.datatype == CCV_32F && b->info.datatype == CCV_16BF) {
@@ -1348,7 +1354,7 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 		} else if (a->info.datatype == CCV_16BF && b->info.datatype == CCV_32F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
 			ccv_bfloat_to_float((uint16_t*)a->data.f16, b->data.f32, tensor_count);
 		} else if (a->info.datatype == CCV_64F && b->info.datatype == CCV_16BF) {
@@ -1360,7 +1366,7 @@ static int _ccv_nnc_datatype_conversion(const ccv_nnc_cmd_t cmd, const ccv_nnc_h
 		} else if (a->info.datatype == CCV_16BF && b->info.datatype == CCV_64F) {
 			assert(CCV_IS_TENSOR_CONTIGUOUS(a));
 			assert(CCV_IS_TENSOR_CONTIGUOUS(b));
-			const int tensor_count = ccv_nnc_tensor_count(a->info);
+			const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 			assert(tensor_count == ccv_nnc_tensor_count(b->info));
 			ccv_bfloat_to_double((uint16_t*)a->data.f16, b->data.f64, tensor_count);
 		}
@@ -1407,8 +1413,9 @@ static void _ccv_nnc_masked_fill_cpu_ref_f(const float p, const float q, ccv_nnc
 	int x;
 	if (!CCV_IS_TENSOR_VIEW(a) && !CCV_IS_TENSOR_VIEW(b) && !CCV_IS_TENSOR_VIEW(c) && a_check_dim && b_check_dim)
 	{
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 		// Super optimal case, just do one for-loop for sum.
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			c->data.f32[x] = (b->data.f32[x] == p) ? q : a->data.f32[x];
 		return;
@@ -1496,8 +1503,9 @@ static void _ccv_nnc_masked_fill_cpu_ref_s(const int p, const float q, ccv_nnc_t
 	int x;
 	if (!CCV_IS_TENSOR_VIEW(a) && !CCV_IS_TENSOR_VIEW(b) && !CCV_IS_TENSOR_VIEW(c) && a_check_dim && b_check_dim)
 	{
-		const int tensor_count = ccv_nnc_tensor_count(a->info);
+		const size_t tensor_count = ccv_nnc_tensor_count(a->info);
 		// Super optimal case, just do one for-loop for sum.
+		size_t x;
 		for (x = 0; x < tensor_count; x++)
 			c->data.f32[x] = (b->data.i32[x] == p) ? q : a->data.f32[x];
 		return;


### PR DESCRIPTION
## Summary

`_ccv_nnc_datatype_conversion` and several fill/masked-fill fast paths in `lib/nnc/cmd/util/ccv_nnc_util_cpu_ref.c` declare their element count as `const int tensor_count = ccv_nnc_tensor_count(a->info)`, while `ccv_nnc_tensor_count` returns `size_t` and the sibling branches already use `const size_t`. For tensors with >= 2^31 elements the `int` wraps, which at best trips the `tensor_count == ccv_nnc_tensor_count(b->info)` assert and at worst silently converts/fills a truncated element count in release builds.

This is not theoretical: the CCV_16F -> CCV_32F branch is hit in production by Draw Things when generating long high-resolution video. An LTX-2.3 clip at 1920x1088 with 601 frames is a contiguous pixel tensor of 601 * 1088 * 1920 * 3 = 3,766,910,976 elements; converting it fp16 -> fp32 on CPU aborts:

```
Assertion failed: (tensor_count == ccv_nnc_tensor_count(b->info)),
function _ccv_nnc_datatype_conversion, file ccv_nnc_util_cpu_ref.c, line 1301.
```

## Changes

- All `const int tensor_count` declarations in this file become `const size_t tensor_count` (13 sites).
- Loop indices that iterate up to `tensor_count` are widened to `size_t` as well (the fill fast paths reusing the function-scope `int x`, the 64F->32F branch's local `int i`, and the 32F->64F branch reusing the function-scope `int i`), since an `int` index would still overflow past 2^31 even with a correct count. The widened variables shadow the function-scope ones only inside their fast-path blocks; behavior for tensors below 2^31 elements is unchanged.
- Branches that pass `tensor_count` to the conversion helpers (`ccv_half_precision_to_float` etc., all taking `size_t len`) need only the declaration change.

## Testing

- Verified end-to-end via Draw Things `draw-things-cli` built against this patch on an M5 Max (macOS 26): a 1920x1088, 601-frame LTX-2.3 generation, which deterministically aborted at the assert above, completes and produces a correct video once the CCV_16F -> CCV_32F conversion runs with a `size_t` count.
- Regression smoke test: short generations (below the 2^31 threshold) behave identically before/after.
- The other widened branches are the same bug class but were not individually exercised with >= 2^31 tensors; they are mechanical applications of the same fix.

Found while chasing a crash chain in drawthingsai/draw-things-community (companion PR linked there). Opening as a draft to hear whether you'd prefer a different shape for the fix (e.g. a repo-wide sweep of this pattern rather than this file only — `grep -rn "const int tensor_count"` shows further candidates elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
